### PR TITLE
Basic logic fo test run statuses and error code reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ branches:
     - dev
 
 install:
-  - pip install numpy
+  - pip install numpy pytest
 
 script:
   - export PYTHONPATH=$PWD:$PYTHONPATH
   - ./tests/runTests.py -d # default config
   - yes | ./tests/runTests.py -f # run tests, returning error code
+  - python -m pytest tests/enum23/test_enum23.py

--- a/sciath/_enum23.py
+++ b/sciath/_enum23.py
@@ -1,0 +1,26 @@
+# Defines a class which behaves like an Enum (Python 3.4+)
+# But also supports some operations with earlier versions of Python
+# It is used just like Enum, except that values must be assigned
+# Using Enum23Value(), not directly, for example
+#
+# class MyEnum(Enum23):
+#    FOO = Enum23Value('foo')
+#
+# If Python <3.4 support is dropped, Enum23 can be directly replaced
+# with Enum, and Enum23Value() can be removed
+
+import sys
+
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
+    from enum import Enum
+
+    def Enum23Value(x):
+        return x
+
+    Enum23 = Enum
+else:
+    class Enum23Value:
+        """ A wrapper class which allows one to access a value field """
+        def __init__(self, value): self.__dict__.update(value=value)
+
+    Enum23 = object

--- a/tests/enum23/test_enum23.py
+++ b/tests/enum23/test_enum23.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# Run e.g.
+#  python -m pytest this_file.py
+
+import pytest
+
+from sciath._enum23 import Enum23, Enum23Value
+
+def test_enum_value_equality():
+    class MyEnum(Enum23):
+        FOO = Enum23Value('foo')
+
+    x = MyEnum.FOO
+    assert(x == MyEnum.FOO)
+
+def test_enum_value():
+    class MyEnum(Enum23):
+        FOO = Enum23Value('foo')
+        BAR = Enum23Value('bar')
+
+    x = MyEnum.FOO
+    assert(x.value == 'foo')
+    y = MyEnum.BAR
+    assert(y.value == 'bar')

--- a/tests/harness/test3.py
+++ b/tests/harness/test3.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# "Command line" use of the Harness, with all tests passing
+
+from sciath.harness import Harness
+from sciath.test import Test
+from sciath.job import Job
+
+test1 = Test(Job(['echo','Hello, I am Test #1']),'test1')
+test2 = Test(Job(['printf','Hello, I am Test #2\n']),'test2')
+test_list = [test1,test2]
+
+harness = Harness(test_list)
+harness.run_from_args()


### PR DESCRIPTION
Introduces an new class, Enum23, which works Enum in Python 3.4+,
but also provides enough functionality to work with older versions
of Python.

Some TODOs are left in Harness.verify() for as-yet-unresolved issues

closes #54 
closes #55 