### PR TITLE
Line Verifier

### DIFF
--- a/sciath/verifier_line.py
+++ b/sciath/verifier_line.py
@@ -1,0 +1,45 @@
+import os
+import re
+
+from sciath.verifier import Verifier
+from sciath import sciath_test_status
+
+class VerifierLine(Verifier):
+
+    def __init__(self, test, expected_file, output_file = None):
+      Verifier.__init__(self, test)
+      self.expected_file = expected_file
+      c_name, o_name, e_name = self.test.job.get_output_filenames()
+      if output_file is None:
+          self.output_file = o_name[-1]
+      self.rules = []
+
+    def execute(self, output_path, exec_path = None):
+        passing = True
+        report = ''
+        for rule in self.rules:
+
+            if not os.path.isfile(self.expected_file):
+                status = sciath_test_status.expected_file_not_found
+                break
+            output_file_full = os.path.join(output_path,self.output_file)
+            if not os.path.isfile(output_file_full):
+                status = sciath_test_status.output_file_not_found
+                break
+            match_out = {}
+            match_expected = {}
+            for [match, filename] in [(match_out, output_file_full),(match_expected,self.expected_file)]:
+                with open(filename,'r') as f:
+                    line_number = 0
+                    for line in f.readlines():
+                        line_number = line_number + 1
+                        if re.match(rule['re'],line):
+                            match[line_number] = line
+            rule_result, rule_report  = rule['function'](match_expected, match_out)
+            passing = passing and rule_result
+            if rule_report:
+                report = report + 'Report for lines matching: \'' + rule['re'] + '\'\n'
+                report = report + rule_report
+
+        status = sciath_test_status.ok if passing else sciath_test_status.not_ok
+        return status, report

--- a/sciath/verifier_line.py
+++ b/sciath/verifier_line.py
@@ -43,3 +43,59 @@ class VerifierLine(Verifier):
 
         status = sciath_test_status.ok if passing else sciath_test_status.not_ok
         return status, report
+
+# Helper functions to generate rules
+
+# TODO this is just a proof of concept
+
+def string_get_floats(line):
+    r = []
+    re_float = re.compile('[+-]?\d+.?\d*[eE]?[+-]?\d*')
+    for word in line.split():
+        match = re.search(re_float,word)
+        if match:
+            r.append(float(match.group()))
+    return r
+
+def compare_float_values_rel(line_expected, line_out, rel_tol):
+    floats_expected = string_get_floats(line_expected.rstrip())
+    floats_out      = string_get_floats(line_out.rstrip())
+    passing = True
+    report = ''
+    for (float_expected, float_out) in zip(floats_expected, floats_out):
+        if float_expected == 0.0 and float_out != 0.0:
+            passing = False
+            report = report + 'expected value of 0.0 must be matched exactly (not checking the rest of the line)\n'
+            break
+        if abs(float_out - float_expected)/abs(float_expected) > rel_tol:
+             passing = False
+             report = report + 'expected value of ' + str(float_expected) + ' does not match output value ' + str(float_out) + ' to relative tolerance ' + str(rel_tol)
+             break
+    if passing and len(floats_expected) != len(floats_out):
+        passing = False
+        report = report + 'Wrong number of values found: ' + len(floats_out) + ' instead of ' + len(floats_expected)
+    return passing, report
+
+def float_rel_pairs_function(match_expected, match_out, rel_tol, max_err_count = 100):
+    passing = True
+    report = ''
+    err_count = 0
+    for ((lineno_expected,line_expected), (lineno_out,line_out)) in zip(match_expected.items(), match_out.items()):
+        line_passing, line_report = compare_float_values_rel(line_expected, line_out, rel_tol)
+        if not line_passing:
+            passing = False
+            report = report + '(l.' + str(lineno_expected) + '/' + str(lineno_out) + ') Lines did not match: ' + line_report
+
+            err_count = err_count + 1
+            if err_count > max_err_count:
+                report = report + 'Not checking any more lines after the first ' + max_err_count + '\n'
+    if len(match_expected) != len(match_out):
+        passing = False
+        report = report + 'Output and expected had different numbers of matches. Expected ' + len(match_expected) + ' but found ' + len(match_out) + '\n'
+    return passing, report
+
+def key_and_float_rule(key,rel_tol=1e-6):
+    rule = {}
+    rule['re'] = '^'+re.escape(key) # match on lines starting with key
+    rule['function'] = lambda e,o : float_rel_pairs_function(e,o,rel_tol=rel_tol)
+    return rule

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -94,6 +94,13 @@ def TestTest2():
     t.setUseSandbox()
     return t
 
+def TestTestLine1():
+    t = Test('TestTestLine1',1, ['cp '  + abs_path('./test_conf') + ' ' + 'SciATHBatchQueuingSystem.conf', 'python ' + abs_path('./test/test_line_verifier.py') ], abs_path('test/test_line_verifier.expected'))
+    t.setVerifyMethod(lambda t: t.compareUnixDiff())
+    t.appendKeywords('[Executing') # skip since absolute path is printed
+    t.setUseSandbox()
+    return t
+
 def main():
     print('SciATH Self-tests')
     print('Testing with version',getStableVersion(),'from',stablePackage.__file__)
@@ -109,6 +116,7 @@ def main():
         LauncherTest1(),
         TestTest1(),
         TestTest2(),
+        TestTestLine1(),
         ])
     harness.execute()
     harness.verify()

--- a/tests/test/expected/line1.expected
+++ b/tests/test/expected/line1.expected
@@ -1,8 +1,8 @@
   key 2.0 2 -3.4 1e10
 x
 
-  key 3.0
-  key  
+  key 1.0
+  key
 key
 key 7e-10 3.0 4.0
-  key 1e-1
+  key 1e-12

--- a/tests/test/expected/line1.expected
+++ b/tests/test/expected/line1.expected
@@ -1,0 +1,8 @@
+  key 2.0 2 -3.4 1e10
+x
+
+  key 3.0
+  key  
+key
+key 7e-10 3.0 4.0
+  key 1e-1

--- a/tests/test/test_ex1.py
+++ b/tests/test/test_ex1.py
@@ -6,7 +6,6 @@ from sciath.job import JobSequence
 from sciath.job import JobDAG
 from sciath.launcher import Launcher
 from sciath.test import Test
-from sciath.verifier_unixdiff import VerifierUnixDiff
 
 OUTPUT_PATH = os.path.join(os.getcwd(),'output')
 VERBOSITY = 0

--- a/tests/test/test_line_verifier.expected
+++ b/tests/test/test_line_verifier.expected
@@ -1,0 +1,9 @@
+[36m[Executing Line1][0m from /Users/patrick/code/sciath/tests/test
+  [cmd]  ['printf', '  key 1.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-12\n']
+['pass', 'verification was successful']
+
+[36m[Executing Line2][0m from /Users/patrick/code/sciath/tests/test
+  [cmd]  ['printf', 'should fail\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-12\n']
+['fail', 'verification failed']
+Report for lines matching: '  key'
+Failure: Different numbers of matching lines found: 4 expected but 3 found

--- a/tests/test/test_line_verifier.expected
+++ b/tests/test/test_line_verifier.expected
@@ -7,3 +7,17 @@
 ['fail', 'verification failed']
 Report for lines matching: '  key'
 Failure: Different numbers of matching lines found: 4 expected but 3 found
+[36m[Executing Line3][0m from /Users/patrick/code/sciath/tests/test
+  [cmd]  ['printf', '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 1.0 4.0\n  key 1e-12\n']
+['pass', 'verification was successful']
+
+[36m[Executing Line4][0m from /Users/patrick/code/sciath/tests/test
+  [cmd]  ['printf', '  key 7.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e-12\n']
+['fail', 'verification failed']
+Report for lines matching: '^\ \ key'
+(l.1/1) Lines did not match: expected value of 2.0 does not match output value 7.0 to relative tolerance 1e-06
+[36m[Executing Line5][0m from /Users/patrick/code/sciath/tests/test
+  [cmd]  ['printf', '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e+12\n']
+['fail', 'verification failed']
+Report for lines matching: '^\ \ key'
+(l.8/8) Lines did not match: expected value of 1e-12 does not match output value 1000000000000.0 to relative tolerance 1e-06

--- a/tests/test/test_line_verifier.py
+++ b/tests/test/test_line_verifier.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import os
+
+from sciath.job import Job
+from sciath.launcher import Launcher
+from sciath.test import Test
+from sciath.verifier_line import VerifierLine
+
+this_dir = os.path.dirname(os.path.realpath(__file__))
+
+def comparison_function(match_expected, match_out):
+    """ Simply check that the same number of matches are found in expected and output files"""
+    n_expected = len(match_expected)
+    n_found = len(match_out)
+    passing = n_found == n_expected
+    report = None if passing else 'Failure: Different numbers of matching lines found: ' + str(n_expected) + ' expected but ' + str(n_found) + ' found'
+    return passing, report
+
+def test1(output_path):
+    cmd = ['printf' , '  key 1.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-12\n']
+    name = 'Line1'
+    t = Test(Job(cmd, name))
+    v = VerifierLine(t, expected_file = os.path.join(this_dir,"./expected/line1.expected"))
+    v.rules.append({'re':'  key', 'function':comparison_function})
+    t.verifier = v
+    return t
+
+# The same, but fails
+def test2(output_path):
+    cmd = ['printf' , 'should fail\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-12\n']
+    name = 'Line2'
+    t = Test(Job(cmd, name))
+    v = VerifierLine(t, expected_file = os.path.join(this_dir,"./expected/line1.expected"))
+    v.rules.append({'re':'  key', 'function':comparison_function})
+    t.verifier = v
+    return t
+
+def main():
+    output_path = os.path.join(os.getcwd(),'output')
+    try:
+        os.mkdir(output_path)
+    except:
+        pass
+
+    launcher = Launcher()
+    for t in [test1(output_path), test2(output_path)]:
+        launcher.submitJob(t.job, output_path = output_path) # only makes sense on local machine
+        status, report = t.verify(output_path = output_path)
+        print(status)
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test/test_line_verifier.py
+++ b/tests/test/test_line_verifier.py
@@ -4,7 +4,7 @@ import os
 from sciath.job import Job
 from sciath.launcher import Launcher
 from sciath.test import Test
-from sciath.verifier_line import VerifierLine
+from sciath.verifier_line import VerifierLine, key_and_float_rule
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -35,17 +35,44 @@ def test2(output_path):
     t.verifier = v
     return t
 
+# Compare floats. Should pass with default tol
+def test3(output_path):
+    cmd = ['printf' , '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 1.0 4.0\n  key 1e-12\n']
+    name = 'Line3'
+    t = Test(Job(cmd, name))
+    v = VerifierLine(t, expected_file = os.path.join(this_dir,"./expected/line1.expected"))
+    v.rules.append(key_and_float_rule('  key'))
+    t.verifier = v
+    return t
+
+# Compare floats. Should fail
+def test4(output_path):
+    cmd = ['printf' , '  key 7.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e-12\n']
+    name = 'Line4'
+    t = Test(Job(cmd, name))
+    v = VerifierLine(t, expected_file = os.path.join(this_dir,"./expected/line1.expected"))
+    v.rules.append(key_and_float_rule('  key'))
+    t.verifier = v
+    return t
+
+# Compare floats. Should fail
+def test5(output_path):
+    cmd = ['printf' , '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e+12\n']
+    name = 'Line5'
+    t = Test(Job(cmd, name))
+    v = VerifierLine(t, expected_file = os.path.join(this_dir,"./expected/line1.expected"))
+    v.rules.append(key_and_float_rule('  key'))
+    t.verifier = v
+    return t
+
 def main():
     output_path = os.path.join(os.getcwd(),'output')
-    try:
-        os.mkdir(output_path)
-    except:
-        pass
+    os.makedirs(output_path, exist_ok = True)
 
     launcher = Launcher()
-    for t in [test1(output_path), test2(output_path)]:
-        launcher.submitJob(t.job, output_path = output_path) # only makes sense on local machine
-        status, report = t.verify(output_path = output_path)
+    for t in [test1(output_path), test2(output_path), test3(output_path), test4(output_path), test5(output_path)]:
+        launcher.submitJob(t.job, output_path = output_path)
+        status, report = t.verify(output_path = output_path) # only makes sense if submitJob blocks
         print(status)
         print(report)
 


### PR DESCRIPTION
A (very) minimal implementation of a new Verifier to be extended to cover the types of cases we typically care about with pyTestHarness.

The idea is that you provide a set of "rules", each of which consists of a regular expression to identify matching lines, plus a function to compare those sets of matching lines from the expected and output files (later should be generalized to a "comparison" file). 

Here, the regular express and the function are both just provided directly, but more normal usage would be to use helper functions that SciATH provides to do common things like compare floating point numbers.

This partially addresses #70 