### PR TITLE
YAML input: accept "ranks:"

### DIFF
--- a/sciath/_test_file.py
+++ b/sciath/_test_file.py
@@ -10,7 +10,6 @@ import sciath.verifier_line
 
 
 def create_tests_from_file(filename):
-
     with open(filename, 'r') as input_file:
         data = yaml.safe_load(input_file)
 
@@ -24,80 +23,90 @@ def create_tests_from_file(filename):
     for entry in data:
         if not isinstance(entry, dict):
             raise Exception('Incorrectly formatted test entry (must be a mapping)')
-
-        if 'name' not in entry:
-            raise Exception('Each test entry must specify a name')
-        if not entry['name']:
-            raise Exception('Names cannot be empty')
-
-        if 'command' in entry and 'commands' in entry:
-            raise Exception('Cannot specify both command: and commands:')
-        if 'command' not in entry and 'commands' not in entry:
-            raise Exception('Must specify command: or commands: for each entry')
-        commands_raw = entry['command'] if 'command' in entry else entry['commands']
-        if isinstance(commands_raw, str):
-            commands = [commands_raw]
-        elif isinstance(commands_raw, list):
-            commands = commands_raw
-        else:
-            raise Exception('command: or commands: fields must be a string or a sequence')
-
-        commands = [_replace_here_marker(command, filename) for command in commands]
-
-        commands = [shlex.split(command) for command in commands]  # split, respecting quotes
-        for command in commands:
-            if not command:
-                raise Exception('Commands cannot be empty')
-
-        expected = entry['expected']
-        expected = _replace_here_marker(expected, filename)
-        if not os.path.isabs(expected):
-            expected = os.path.join(os.path.dirname(filename), expected)
-
-        if len(commands) == 1:
-            job = sciath.job.Job(commands[0], name=entry['name'])
-        else:
-            job = sciath.job.JobSequence(commands[-1], name=entry['name'])
-            for i in reversed(range(len(commands)-1)):
-                job.append(sciath.job.Job(commands[i]))
-        test = sciath.test.Test(job, entry['name'])
-
-        comparison_file = entry['comparison'] if 'comparison' in entry else None
-
-        verifier_type = entry['type'] if 'type' in entry else 'text_diff'
-        if verifier_type == 'text_diff':
-            if 'expected' not in entry or not entry['expected']:
-                raise Exception('Each test entry must defined an expected file')
-            test.verifier = sciath.verifier.ComparisonVerifier(
-                    test, expected, comparison_file=comparison_file)
-        elif verifier_type == 'float_lines':
-            if 'expected' not in entry or not entry['expected']:
-                raise Exception('Each test entry must defined an expected file')
-            test.verifier = sciath.verifier_line.LineVerifier(
-                    test, expected, comparison_file=comparison_file)
-            if 'rules' not in entry:
-                raise Exception('rules: expected')
-            rules = entry['rules']
-            if not isinstance(rules, list):
-                raise Exception('rules: should contain a sequence')
-            for rule in rules:
-                if not isinstance(rule, dict):
-                    raise Exception('Each rule should be a mapping')
-                if 'key' not in rule:
-                    raise Exception('Each rule should have a key:')
-                key = rule['key']
-                if 'rtol' in rule:
-                    rule_func = sciath.verifier_line.key_and_float_rule(
-                            key, rel_tol=float(rule['rtol']))
-                else:
-                    rule_func = sciath.verifier_line.key_and_float_rule(key)
-                test.verifier.rules.append(rule_func)
-        else:
-            raise Exception('[SciATH] unrecognized type %s' % verifier_type)
-
+        job = _create_job_from_entry(entry, filename)
+        test = _create_test_from_entry(job, entry, filename)
         tests.append(test)
 
     return tests
+
+
+def _create_job_from_entry(entry, filename):
+    if 'name' not in entry:
+        raise Exception('Each test entry must specify a name')
+    if not entry['name']:
+        raise Exception('Names cannot be empty')
+
+    if 'command' in entry and 'commands' in entry:
+        raise Exception('Cannot specify both command: and commands:')
+    if 'command' not in entry and 'commands' not in entry:
+        raise Exception('Must specify command: or commands: for each entry')
+    commands_raw = entry['command'] if 'command' in entry else entry['commands']
+    if isinstance(commands_raw, str):
+        commands = [commands_raw]
+    elif isinstance(commands_raw, list):
+        commands = commands_raw
+    else:
+        raise Exception('command: or commands: fields must be a string or a sequence')
+
+    commands = [_replace_here_marker(command, filename) for command in commands]
+
+    commands = [shlex.split(command) for command in commands]  # split, respecting quotes
+    for command in commands:
+        if not command:
+            raise Exception('Commands cannot be empty')
+
+    ranks = int(entry['ranks']) if 'ranks' in entry else 1
+
+    if len(commands) == 1:
+        job = sciath.job.Job(commands[0], name=entry['name'], ranks=ranks)
+    else:
+        job = sciath.job.JobSequence(commands[-1], name=entry['name'], ranks=ranks)
+        for i in reversed(range(len(commands)-1)):
+            job.append(sciath.job.Job(commands[i], ranks=ranks))
+    return job
+
+
+def _create_test_from_entry(job, entry, filename):
+    test = sciath.test.Test(job)
+
+    expected = entry['expected']
+    expected = _replace_here_marker(expected, filename)
+    if not os.path.isabs(expected):
+        expected = os.path.join(os.path.dirname(filename), expected)
+
+    comparison_file = entry['comparison'] if 'comparison' in entry else None
+
+    verifier_type = entry['type'] if 'type' in entry else 'text_diff'
+    if verifier_type == 'text_diff':
+        if 'expected' not in entry or not entry['expected']:
+            raise Exception('Each test entry must defined an expected file')
+        test.verifier = sciath.verifier.ComparisonVerifier(
+                test, expected, comparison_file=comparison_file)
+    elif verifier_type == 'float_lines':
+        if 'expected' not in entry or not entry['expected']:
+            raise Exception('Each test entry must defined an expected file')
+        test.verifier = sciath.verifier_line.LineVerifier(
+                test, expected, comparison_file=comparison_file)
+        if 'rules' not in entry:
+            raise Exception('rules: expected')
+        rules = entry['rules']
+        if not isinstance(rules, list):
+            raise Exception('rules: should contain a sequence')
+        for rule in rules:
+            if not isinstance(rule, dict):
+                raise Exception('Each rule should be a mapping')
+            if 'key' not in rule:
+                raise Exception('Each rule should have a key:')
+            key = rule['key']
+            if 'rtol' in rule:
+                rule_func = sciath.verifier_line.key_and_float_rule(
+                        key, rel_tol=float(rule['rtol']))
+            else:
+                rule_func = sciath.verifier_line.key_and_float_rule(key)
+            test.verifier.rules.append(rule_func)
+    else:
+        raise Exception('[SciATH] unrecognized type %s' % verifier_type)
+    return test
 
 
 def _replace_here_marker(string, filename, marker='HERE'):

--- a/sciath/job.py
+++ b/sciath/job.py
@@ -52,10 +52,12 @@ class Job:
         # Design note: we use a dict to enable developers to easily add support for different resource requests
         self.resources = dict()
         self.setResources(**kwargs) # looking in kwargs for any resources
-        if len(self.resources) == 0: # set defaults
-            self.resources.update({"mpiranks":1}) # mpi parallel resource data
-            self.resources.update({"threads":1}) # thread parallel (e.g. OMP) resource data
-            self.resources.update({"idlempirankspernode":0}) # idle ranks-per-compute-node resource data
+        if 'mpiranks' not in self.resources:
+            self.resources['mpiranks'] = 1
+        if 'threads' not in self.resources:
+            self.resources['threads'] = 1
+        if 'idlempirankspernode' not in self.resources:
+            self.resources['idlempirankspernode'] = 0
 
         # optional info not needing a setter (e.g. they are not special enough)
         self.exit_code_success = 0

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -3,7 +3,7 @@
 [ -- Removing output for Test: foo2 -- ]
 [ -- Removing output for Test: foo_fail -- ]
 [ -- Removing output for Test: missing -- ]
-[ -- Removing output for Test: many words -- ]
+[ -- Removing output for Test: many_words -- ]
 [ -- Removing output for Test: comp_file -- ]
 [ -- Removing output for Test: comp_file_fail -- ]
 [35m[ *** Executing Tests *** ][0m
@@ -19,7 +19,7 @@ echo foo
 echo foox
 [36m[Executing missing][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/sandbox
 echo missing
-[36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/many words_output/sandbox
+[36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/many_words_output/sandbox
 echo 'many words'
 [36m[Executing comp_file][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_output/sandbox
 sh -c 'echo qux > compare_me.txt'
@@ -45,7 +45,7 @@ sh -c 'echo qux > compare_me.txt'
 [32m[foo2]  pass[0m (verification was successful)
 [91m[foo_fail]  fail[0m (verification failed)
 [91m[missing]  fail[0m (expected/comparison file not found)
-[32m[many words]  pass[0m (verification was successful)
+[32m[many_words]  pass[0m (verification was successful)
 [32m[comp_file]  pass[0m (verification was successful)
 [91m[comp_file_fail]  fail[0m (verification failed)
 

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -3,7 +3,7 @@
 [ -- Removing output for Test: foo2 -- ]
 [ -- Removing output for Test: foo_fail -- ]
 [ -- Removing output for Test: missing -- ]
-[ -- Removing output for Test: many words -- ]
+[ -- Removing output for Test: many_words -- ]
 [ -- Removing output for Test: comp_file -- ]
 [ -- Removing output for Test: comp_file_fail -- ]
 [35m[ *** Executing Tests *** ][0m
@@ -19,7 +19,7 @@ echo foo
 echo foox
 [36m[Executing missing][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/sandbox
 echo missing
-[36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/many words_output/sandbox
+[36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/many_words_output/sandbox
 echo 'many words'
 [36m[Executing comp_file][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_output/sandbox
 sh -c 'echo qux > compare_me.txt'
@@ -45,7 +45,7 @@ sh -c 'echo qux > compare_me.txt'
 [32m[foo2]  pass[0m (verification was successful)
 [91m[foo_fail]  fail[0m (verification failed)
 [91m[missing]  fail[0m (expected/comparison file not found)
-[32m[many words]  pass[0m (verification was successful)
+[32m[many_words]  pass[0m (verification was successful)
 [32m[comp_file]  pass[0m (verification was successful)
 [91m[comp_file_fail]  fail[0m (verification failed)
 


### PR DESCRIPTION
Split the function to process the file into separate functions to build
the Job and the Test.

Adjust the default resource setting logic for Job so that one need
not specify all three current defaults.

Have the Test inherit the name from the Job (which means that it gets
an underscore, if specified with a space, since Job enforces that, but
Test currently doesn't.)