### PR TITLE
Update Safety

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -231,9 +231,15 @@ class Harness:
 
     def update_expected(self):
         """ Give each active test the chance to update its reference output """
+        if self.testruns:
+            print(sciath_colors.HEADER + '[ *** Updating Expected Output *** ]' + sciath_colors.ENDC)
         for testrun in self.testruns:
             if testrun.active:
-                testrun.test.verifier.update_expected(testrun.output_path, testrun.exec_path)
+                if hasattr(testrun.test.verifier, 'update_expected'):
+                    print('[ -- Updating output for Test:',testrun.test.name,'-- ]')
+                    testrun.test.verifier.update_expected(testrun.output_path, testrun.exec_path)
+                else:
+                    print('[ -- Output updated not supported for Test:',testrun.test.name,'-- ]')
 
     def verify(self):
         """ Update the status of all test runs """

--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -10,6 +10,7 @@ import sciath
 import sciath.launcher
 import sciath._test_file
 from sciath import sciath_colors
+from sciath._io import py23input
 
 class _TestRunStatus(Enum):
     DEACTIVATED             = 'deactivated'  # Test skipped intentionally
@@ -189,6 +190,13 @@ class Harness:
 
         if args.no_colors:
             sciath.sciath_colors.set_colors(use_bash = False)
+
+        if args.update_expected:
+            print("[SciATH] You have provided an argument to updated expected files.")
+            print("[SciATH] This will attempt to OVERWRITE your expected files!")
+            if py23input("[SciATH] Are you sure? Type 'y' to continue: ")[0] not in ['y','Y']:
+                print("[SciATH] Aborting.")
+                return
 
         if args.input_file:
             self.add_tests_from_file(args.input_file)

--- a/sciath/verifier.py
+++ b/sciath/verifier.py
@@ -28,22 +28,6 @@ class Verifier (object):
         """
         raise NotImplementedError("Verifier implementations must override execute()")
 
-    def update_expected(self, output_path=None, exec_path=None):
-        """ Update reference files from output, if possible
-
-            This function can be overridden to give a Verifier implementation
-            the opportunity to update any reference files it refers to,
-            from the output it usually examines. This is very useful for
-            some implementations, as one can quickly generate or
-            update reference files with the same tools used to run the tests.
-
-            Note that if multiple tests refer to the same reference file,
-            a given reference file may be updated several times, and so
-            even in cases where verification is solely based on refernce files,
-            updating may not be a guarantee that verification will succeed.
-
-            """
-
 
 class ExitCodeVerifier(Verifier):
     """ Verifier implementation which checks an error code """
@@ -154,6 +138,14 @@ class ComparisonVerifier(Verifier):
         return self._compare_files(self.expected_file, from_file)
 
     def update_expected(self, output_path=None, exec_path=None):
+        """ Update reference files from output
+
+            Note that if multiple tests refer to the same reference file,
+            a given reference file may be updated several times, and so
+            even in cases where verification is solely based on reference files,
+            updating may not be a guarantee that verification will succeed.
+
+            """
         from_file = self._from_file(output_path, exec_path)
         if not os.path.isfile(from_file) :
             print('[SciATH] Cannot update: source file missing: %s' % from_file)

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -20,7 +20,9 @@ echo foo
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t foo
-[35m[ *** Cleanup *** ][0m
+[SciATH] You have provided an argument to updated expected files.
+[SciATH] This will attempt to OVERWRITE your expected files!
+[SciATH] Are you sure? Type 'y' to continue: [35m[ *** Cleanup *** ][0m
 [ -- Removing output for Test: foo -- ]
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -1,0 +1,50 @@
+[35m[ *** Cleanup *** ][0m
+[ -- Removing output for Test: foo -- ]
+[35m[ *** Executing Tests *** ][0m
+[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+  Version:           0.5.4
+  Queue system:      none
+  MPI launcher:      none
+[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
+echo foo
+[35m[ *** Verification Reports *** ][0m
+[36m[Report for foo][0m
+--- expected
++++ <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sciath.job-foo.stdout
+@@ -1 +1 @@
+-bar
++foo
+[35m[ *** Summary *** ][0m
+[91m[foo]  fail[0m (verification failed)
+
+[91mFAILURE[0m
+To re-run failed tests, use e.g.
+  -t foo
+[35m[ *** Cleanup *** ][0m
+[ -- Removing output for Test: foo -- ]
+[35m[ *** Executing Tests *** ][0m
+[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+  Version:           0.5.4
+  Queue system:      none
+  MPI launcher:      none
+[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
+echo foo
+[35m[ *** Updating Expected Output *** ][0m
+[ -- Updating output for Test: foo -- ]
+[35m[ *** Summary *** ][0m
+[32m[foo]  pass[0m (verification was successful)
+
+[32mSUCCESS[0m
+[35m[ *** Cleanup *** ][0m
+[ -- Removing output for Test: foo -- ]
+[35m[ *** Executing Tests *** ][0m
+[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+  Version:           0.5.4
+  Queue system:      none
+  MPI launcher:      none
+[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
+echo foo
+[35m[ *** Summary *** ][0m
+[32m[foo]  pass[0m (verification was successful)
+
+[32mSUCCESS[0m

--- a/tests/test_data/verifier_update/input.yml
+++ b/tests/test_data/verifier_update/input.yml
@@ -1,0 +1,4 @@
+-
+  name: foo
+  command: echo foo
+  ## expected here:

--- a/tests/test_data/verifier_update/verifier_update.sh
+++ b/tests/test_data/verifier_update/verifier_update.sh
@@ -22,7 +22,7 @@ printf '  expected: expected\n' >> input.yml
 $python -m sciath $args1 \
   | sed "s%$test_dir%<<TEST DIR STRIPPED>>%g"
 
-$python -m sciath $args2 \
+printf 'yessiree' | $python -m sciath $args2 \
   | sed "s%$test_dir%<<TEST DIR STRIPPED>>%g"
 
 $python -m sciath $args1 \

--- a/tests/test_data/verifier_update/verifier_update.sh
+++ b/tests/test_data/verifier_update/verifier_update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+test_name=verifier_update
+test_dir=$(pwd)
+sandbox="$test_name""_sandbox"
+test_conf="test_conf"
+python=python
+
+args1="-i input.yml"
+args2="-i input.yml -u"
+
+rm -rf $sandbox
+mkdir $sandbox
+cp $test_conf "$sandbox""/SciATHBatchQueuingSystem.conf"
+cd $sandbox
+
+# Generate expected file
+echo bar > expected
+cp ../test_data/verifier_update/input.yml .
+printf '  expected: expected\n' >> input.yml
+
+$python -m sciath $args1 \
+  | sed "s%$test_dir%<<TEST DIR STRIPPED>>%g"
+
+$python -m sciath $args2 \
+  | sed "s%$test_dir%<<TEST DIR STRIPPED>>%g"
+
+$python -m sciath $args1 \
+  | sed "s%$test_dir%<<TEST DIR STRIPPED>>%g"

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -58,3 +58,7 @@
   name: job_sequence
   command: sh test_wrapper.sh job_sequence test_data/job_sequence/test_jobsequence.py
   expected: test_data/job_sequence.expected
+-
+  name: verifier_update
+  command: sh test_data/verifier_update/verifier_update.sh
+  expected: test_data/verifier_update.expected


### PR DESCRIPTION
Produce output when updating expected files.

Confirm when providing the flag to update (since it's very very easy to accidentally do this if you're hitting "up" to re-run tests).