### PR TITLE
ExitCodeVerifier: keep track of exit codes denoting success

### DIFF
--- a/sciath/job.py
+++ b/sciath/job.py
@@ -46,9 +46,6 @@ class Job:
         """
         return [task.createExecuteCommand() for task in self.tasks]
 
-    def exit_codes_success(self):
-        return [task.exit_code_success for task in self.tasks]
-
     def get_output_filenames(self):
         """ Returns name lists for error-code file (one per job), stdout, stderr """
         errorCodeName = "sciath.job-" +  self.name + ".errorcode"
@@ -77,6 +74,9 @@ class Job:
                 if value > max_resources[key]:
                     max_resources[key] = value
         return max_resources
+
+    def number_tasks(self):
+        return len(self.tasks)
 
     def total_wall_time(self):
         """

--- a/sciath/task.py
+++ b/sciath/task.py
@@ -14,22 +14,18 @@ class Task(object):
        time to allocate.
     """
 
-    def __init__(self, command, exitCode=0, **kwargs):
+    def __init__(self, command, **kwargs):
         self.command = command
         self.resources = dict()
         for key, value in kwargs.items():
             self.resources[key] = value
 
-        # Design note: we use a dict to enable developers to easily add support for different resource requests
-        self.resources = dict()
         self.setResources(**kwargs) # looking in kwargs for any resources
         if 'mpiranks' not in self.resources:
             self.resources['mpiranks'] = 1
         if 'threads' not in self.resources:
             self.resources['threads'] = 1
 
-        # optional info not needing a setter (e.g. they are not special enough)
-        self.exit_code_success = exitCode
         self.wall_time         = 10.0/60.0 # 10 secs (in minutes)
 
         for key, value in kwargs.items():

--- a/tests/test_data/job/test_job.py
+++ b/tests/test_data/job/test_job.py
@@ -14,7 +14,7 @@ taskB.setResources(ranks=140)
 
 taskC = sciath.task.Task('echo \"task 3\"')
 
-taskD = sciath.task.Task('echo \"task 4\"',exitCode=0)
+taskD = sciath.task.Task('echo \"task 4\"')
 taskD.setResources(threads=27,ranks=40)
 
 job = sciath.job.Job([taskA, taskB, taskC, taskD], name='Four-task job')

--- a/tests/test_data/test1/test_ex1.py
+++ b/tests/test_data/test1/test_ex1.py
@@ -41,7 +41,8 @@ def test2(): # result: pass
 def test3(): # result: fail
     cmd = ['echo' , '"aBc";' , 'echo' '"kspits=30"' ]
 
-    t = Test(Job(Task(cmd, exitCode=1), 'Test_3'))
+    t = Test(Job(Task(cmd), 'Test_3'))
+    t.verifier.set_exit_codes_success([1])
     job_launcher.submitJob( t.job, output_path = OUTPUT_PATH )
     t.verify(output_path = OUTPUT_PATH)
     test_print(t, output_path = OUTPUT_PATH)


### PR DESCRIPTION
Move the storage of exit codes for success from Task to
ExitCodeVerifier. This is cleaner because "success" is a concept to do
with evaluating a test, and indeed it would be possible for the same
Task to be involved in two different Tests, with different expected exit
codes.

Closes #98 