### PR TITLE
Self-tests: add verify_tests.sh script

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,4 +16,4 @@ fi
 ./minisciath/minisciath.py --exclude-group mpi_verify tests.yml $@
 
 printf "You should run additional tests to verify MPI tests. Wait until any queued jobs are completed, and then run\n"
-printf "  ./minisciath/minisciath.py --only-group mpi_verify tests.yml\n"
+printf "  ./verify_tests.sh\n"

--- a/tests/verify_tests.sh
+++ b/tests/verify_tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+./minisciath/minisciath.py --only-group mpi_verify tests.yml


### PR DESCRIPTION
This allows one to run the second stage of the MPI self tests on a
cluster, after the original instructions have scrolled away.