### PR TITLE
Harness: don't declare success or failure if no tests active

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -162,13 +162,16 @@ class Harness:
                     print(' (' + testrun.status_info + ')', end='')
                 print()
             print()
-            if self.determine_overall_success():
-                print(SCIATH_COLORS.OK + "SUCCESS" + SCIATH_COLORS.ENDC)
+            if any((testrun.active for testrun in self.testruns)):
+                if self.determine_overall_success():
+                    print(SCIATH_COLORS.OK + "SUCCESS" + SCIATH_COLORS.ENDC)
+                else:
+                    print(SCIATH_COLORS.FAIL + "FAILURE" + SCIATH_COLORS.ENDC)
+                    if failed_names:
+                        print('To re-run failed tests, use e.g.')
+                        print('  -t ' + ','.join(failed_names))
             else:
-                print(SCIATH_COLORS.FAIL + "FAILURE" + SCIATH_COLORS.ENDC)
-                if failed_names:
-                    print('To re-run failed tests, use e.g.')
-                    print('  -t ' + ','.join(failed_names))
+                print("No tests active")
         else:
             print("No tests")
 


### PR DESCRIPTION
Instead print a message that no tests were active.

This usually is because of a typo at the command line where
non-existent tests or groups are specified.