### PR TITLE
Harness: dump report to file

### DIFF
--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -26,3 +26,6 @@ echo testE
 [32m[testE]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -29,3 +29,6 @@ grep foo bar
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t test4
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -29,3 +29,6 @@ grep foo bar
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t test4
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -15,3 +15,6 @@ printf 'Hello, I am Test #2\n'
 [32m[test2]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -52,3 +52,6 @@ sh -c 'echo qux > compare_me.txt'
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t foo_fail,missing,comp_file_fail
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -20,3 +20,6 @@ Output line 1 did not match line 1 in expected output:
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t test
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -52,3 +52,6 @@ sh -c 'echo qux > compare_me.txt'
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t foo_fail,missing,comp_file_fail
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -29,3 +29,6 @@ Wrong number of matched lines: 4 instead of 3
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t bar
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -23,3 +23,6 @@ echo testB
 [32m[testB]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -11,3 +11,6 @@ sh <<TEST DIR STRIPPED>>/test_data/module_relpath/script.sh <<TEST DIR STRIPPED>
 [32m[relpath_test]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/module_smoke.expected
+++ b/tests/test_data/module_smoke.expected
@@ -1,1 +1,4 @@
 No tests
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/mpi_smoke_two_ranks_verify.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_verify.expected
@@ -2,3 +2,6 @@
 [32m[two_ranks]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/mpi_smoke_verify.expected
+++ b/tests/test_data/mpi_smoke_verify.expected
@@ -2,3 +2,6 @@
 [32m[two_ranks]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -15,3 +15,6 @@
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t two_ranks
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -153,3 +153,6 @@ Output line 11 did not match line 11 in expected output:
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t rtol_only_default_fail,rtol_only_fail,atol_only_fail,both_tols_fail,atol_zero_fail,rtol_zero_fail,both_tols_zero_fail
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -20,6 +20,9 @@ echo foo
 [91mFAILURE[0m
 To re-run failed tests, use e.g.
   -t foo
+
+Report written to file:
+  sciath_test_report.txt
 [SciATH] You have provided an argument to updated expected files.
 [SciATH] This will attempt to OVERWRITE your expected files!
 [SciATH] Are you sure? Type 'y' to continue: [35m[ *** Cleanup *** ][0m
@@ -37,6 +40,9 @@ echo foo
 [32m[foo]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt
 [35m[ *** Cleanup *** ][0m
 [ -- Removing output for Test: foo -- ]
 [35m[ *** Executing Tests *** ][0m
@@ -50,3 +56,6 @@ echo foo
 [32m[foo]  pass[0m (verification was successful)
 
 [32mSUCCESS[0m
+
+Report written to file:
+  sciath_test_report.txt

--- a/tests/verify_tests.sh
+++ b/tests/verify_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-./minisciath/minisciath.py --only-group mpi_verify tests.yml
+./minisciath/minisciath.py --only-group mpi_verify tests.yml "$@"


### PR DESCRIPTION
This is a feature from pyTestHarness that's being quickly re-introduced, so that a report for failed tests can quickly be copied or emailed elsewhere.

 For now the entire error reports go both to stdout and the file. The error report format is not particularly readable, so I think that the question of how much output to dump to stdout should be delayed until it's more fixed what that output will look like.