### PR TITLE
Report file: use full path

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -76,6 +76,7 @@ class Harness:
         if tests:
             for test in tests:
                 self.add_test(test)
+        self.report_filename_full = os.path.join(os.getcwd(), self._report_filename)
 
     def add_test(self, test):
         """ Add a Test to be run with the harness """
@@ -204,7 +205,7 @@ class Harness:
             print(line)
 
         self._report_to_file(report)
-        print('\nReport written to file:\n  %s' %(self._report_filename))
+        print('\nReport written to file:\n  %s' %(self.report_filename_full))
 
     def _report_to_file(self, report):
         """ Dumps a report, as a list of lines (no new-lines) to file
@@ -212,7 +213,7 @@ class Harness:
             Prepends additional information, so that the file can be
             sent elsewhere or referred to later
         """
-        with open(self._report_filename, 'w') as handle:
+        with open(self.report_filename_full, 'w') as handle:
             handle.write(datetime.datetime.now().strftime('%m/%d/%Y, %H:%M:%S') + '\n')
             handle.write(str(self.launcher) + '\n')
             handle.write('\n'.join(report) + '\n')

--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -28,4 +28,4 @@ echo testE
 [32mSUCCESS[0m
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/groups_sandbox/sciath_test_report.txt

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -31,4 +31,4 @@ To re-run failed tests, use e.g.
   -t test4
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/harness1_sandbox/sciath_test_report.txt

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -31,4 +31,4 @@ To re-run failed tests, use e.g.
   -t test4
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/harness2_sandbox/sciath_test_report.txt

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -17,4 +17,4 @@ printf 'Hello, I am Test #2\n'
 [32mSUCCESS[0m
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/harness3_sandbox/sciath_test_report.txt

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -54,4 +54,4 @@ To re-run failed tests, use e.g.
   -t foo_fail,missing,comp_file_fail
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/harness4_sandbox/sciath_test_report.txt

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -22,4 +22,4 @@ To re-run failed tests, use e.g.
   -t test
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/harness5_sandbox/sciath_test_report.txt

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -54,4 +54,4 @@ To re-run failed tests, use e.g.
   -t foo_fail,missing,comp_file_fail
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/module_input_sandbox/sciath_test_report.txt

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -31,4 +31,4 @@ To re-run failed tests, use e.g.
   -t bar
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/module_input_sandbox/sciath_test_report.txt

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -25,4 +25,4 @@ echo testB
 [32mSUCCESS[0m
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/module_multi_sandbox/sciath_test_report.txt

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -13,4 +13,4 @@ sh <<TEST DIR STRIPPED>>/test_data/module_relpath/script.sh <<TEST DIR STRIPPED>
 [32mSUCCESS[0m
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/module_relpath_sandbox/sciath_test_report.txt

--- a/tests/test_data/module_smoke.expected
+++ b/tests/test_data/module_smoke.expected
@@ -1,4 +1,4 @@
 No tests
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/module_smoke_sandbox/sciath_test_report.txt

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -17,4 +17,4 @@ To re-run failed tests, use e.g.
   -t two_ranks
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/sciath_test_report.txt

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -155,4 +155,4 @@ To re-run failed tests, use e.g.
   -t rtol_only_default_fail,rtol_only_fail,atol_only_fail,both_tols_fail,atol_zero_fail,rtol_zero_fail,both_tols_zero_fail
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/sciath_test_report.txt

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -22,7 +22,7 @@ To re-run failed tests, use e.g.
   -t foo
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/verifier_update_sandbox/sciath_test_report.txt
 [SciATH] You have provided an argument to updated expected files.
 [SciATH] This will attempt to OVERWRITE your expected files!
 [SciATH] Are you sure? Type 'y' to continue: [35m[ *** Cleanup *** ][0m
@@ -42,7 +42,7 @@ echo foo
 [32mSUCCESS[0m
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/verifier_update_sandbox/sciath_test_report.txt
 [35m[ *** Cleanup *** ][0m
 [ -- Removing output for Test: foo -- ]
 [35m[ *** Executing Tests *** ][0m
@@ -58,4 +58,4 @@ echo foo
 [32mSUCCESS[0m
 
 Report written to file:
-  sciath_test_report.txt
+  <<TEST DIR STRIPPED>>/verifier_update_sandbox/sciath_test_report.txt


### PR DESCRIPTION
Create the report file in the working directory, as before.

Store and print the absolute path to it, under the general
principle of least astonishment - even if someone wraps SciATH up to call
from some other script, users should be able to find the
output file unambiguously.