### PR TITLE
Launcher: remove max ranks per node field

### DIFF
--- a/sciath/_teststatus.py
+++ b/sciath/_teststatus.py
@@ -68,11 +68,3 @@ class SciathTestStatusDefinition: #pylint: disable=too-few-public-methods,too-ma
             'skip',
             'resource request cannot be satisifed - no MPI exec provided',
         ]
-        self.resources_invalid_gpu = [
-            'skip',
-            'resource request cannot be satisifed - no GPU info provided',
-        ]
-        self.resources_invalid_mpiranks_per_node = [
-            'skip',
-            'resource request cannot be satisifed - insufficient mpiranks-per-node',
-        ]


### PR DESCRIPTION
This isn't currently used, and may never be, for instance if
Launcher configuration is done with a template file.

Also remove an unused status stub related to GPUs.