### PR TITLE
Launcher: expand environment variables in MPI launcher command

### DIFF
--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -447,7 +447,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         while not user_input:
             prompt = ('[2] MPI launch command with num. procs. flag '
                       '(required - hit enter for examples): ')
-            user_input = py23input(prompt)
+            user_input = os.path.expandvars(py23input(prompt))
             if not user_input:
                 print(' Required. Some example MPI launch commands:')
                 print('  No MPI Required           : none')


### PR DESCRIPTION
This allows for the convenience of defining a "good" MPI (e.g.
valgrind-clean MPICH) and using it, or using MPI from the current PETSc,
without as much copy-pasting.