### PR TITLE
Line Verifier: condense report output

### DIFF
--- a/sciath/verifier_line.py
+++ b/sciath/verifier_line.py
@@ -68,7 +68,7 @@ def compare_float_values_line(line_expected, line_out, abs_tol, rel_tol):
             if abs_tol is not None:
                 abs_err = abs(float_out - float_expected)
                 passing_abs = abs_err <= abs_tol
-            if rel_tol is not None and (not abs_tol or not passing_abs):
+            if rel_tol is not None and (abs_tol is None or not passing_abs):
                 if float_expected == 0.0:  # allow to pass rtol an exact match of zero
                     rel_err = float('inf')
                     passing_rel = float_out == 0.0
@@ -77,13 +77,17 @@ def compare_float_values_line(line_expected, line_out, abs_tol, rel_tol):
                     passing_rel = rel_err <= rel_tol
             if (abs_tol is None or not passing_abs) and (rel_tol is None or not passing_rel):
                 passing = False
-                if abs_tol is not None and not passing_abs:
+                if abs_tol is not None and rel_tol is not None:
                     report.append(
-                        '%g does not match expected %g to abs. tol. %g (abs. err %g)'
+                        '%g != %g to abs. tol. %g (abs. err %g) or rel. tol %g (rel. err %g)'
+                        % (float_out, float_expected, abs_tol, abs_err, rel_tol, rel_err))
+                elif abs_tol is not None:
+                    report.append(
+                        '%g != %g to abs. tol. %g (abs. err %g)'
                         % (float_out, float_expected, abs_tol, abs_err))
-                if rel_tol is not None and not passing_rel:
+                else:
                     report.append(
-                        '%g does not match expected %g to rel. tol. %g (rel. err. %g)'
+                        '%g != %g to rel. tol. %g (rel. err. %g)'
                         % (float_out, float_expected, rel_tol, rel_err))
     return passing, report
 

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -13,7 +13,7 @@ echo 'The first number is 1.1\nThe second number is 1.01'
 +++ <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/sciath.job-0-job.stdout
 Report for lines matching: '^\s*The\ first\ number\ is'
 Output line 1 did not match line 1 in expected output:
-1.1 does not match expected 7 to rel. tol. 1e-06 (rel. err. 0.842857)
+1.1 != 7 to rel. tol. 1e-06 (rel. err. 0.842857)
 [35m[ *** Summary *** ][0m
 [91m[test]  fail[0m (verification failed)
 

--- a/tests/test_data/verifier_line.expected
+++ b/tests/test_data/verifier_line.expected
@@ -18,7 +18,7 @@ printf '  key 7.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n 
 +++ <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/sciath.job-0-Line4.stdout
 Report for lines matching: '^\s*\ \ key'
 Output line 1 did not match line 1 in expected output:
-7 does not match expected 2 to rel. tol. 1e-06 (rel. err. 2.5)
+7 != 2 to rel. tol. 1e-06 (rel. err. 2.5)
 [36m[Executing Line5][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
 printf '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e+12\n'
 ['fail', 'verification failed']
@@ -26,4 +26,4 @@ printf '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n 
 +++ <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/sciath.job-0-Line5.stdout
 Report for lines matching: '^\s*\ \ key'
 Output line 8 did not match line 8 in expected output:
-1e+12 does not match expected 1e-12 to rel. tol. 1e-06 (rel. err. 1e+24)
+1e+12 != 1e-12 to rel. tol. 1e-06 (rel. err. 1e+24)

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -34,112 +34,100 @@ cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/sciath.job-0-rtol_only_default_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 5 did not match line 5 in expected output:
-1.0001 does not match expected 1.0002 to rel. tol. 1e-06 (rel. err. 9.998e-05)
+1.0001 != 1.0002 to rel. tol. 1e-06 (rel. err. 9.998e-05)
 Output line 9 did not match line 9 in expected output:
-1e-100 does not match expected 0 to rel. tol. 1e-06 (rel. err. inf)
+1e-100 != 0 to rel. tol. 1e-06 (rel. err. inf)
 Output line 10 did not match line 10 in expected output:
-1.1e-100 does not match expected 1e-99 to rel. tol. 1e-06 (rel. err. 0.89)
+1.1e-100 != 1e-99 to rel. tol. 1e-06 (rel. err. 0.89)
 Output line 11 did not match line 11 in expected output:
-1e-14 does not match expected 1e-16 to rel. tol. 1e-06 (rel. err. 99)
-1.00001 does not match expected 1 to rel. tol. 1e-06 (rel. err. 1e-05)
+1e-14 != 1e-16 to rel. tol. 1e-06 (rel. err. 99)
+1.00001 != 1 to rel. tol. 1e-06 (rel. err. 1e-05)
 [36m[Report for rtol_only_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/sciath.job-0-rtol_only_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 9 did not match line 9 in expected output:
-1e-100 does not match expected 0 to rel. tol. 0.001 (rel. err. inf)
+1e-100 != 0 to rel. tol. 0.001 (rel. err. inf)
 Output line 10 did not match line 10 in expected output:
-1.1e-100 does not match expected 1e-99 to rel. tol. 0.001 (rel. err. 0.89)
+1.1e-100 != 1e-99 to rel. tol. 0.001 (rel. err. 0.89)
 Output line 11 did not match line 11 in expected output:
-1e-14 does not match expected 1e-16 to rel. tol. 0.001 (rel. err. 99)
+1e-14 != 1e-16 to rel. tol. 0.001 (rel. err. 99)
 [36m[Report for atol_only_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/sciath.job-0-atol_only_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
-2 does not match expected 2 to abs. tol. 1e-12 (abs. err 2e-06)
+2 != 2 to abs. tol. 1e-12 (abs. err 2e-06)
 Output line 5 did not match line 5 in expected output:
-1.0001 does not match expected 1.0002 to abs. tol. 1e-12 (abs. err 0.0001)
+1.0001 != 1.0002 to abs. tol. 1e-12 (abs. err 0.0001)
 Output line 8 did not match line 8 in expected output:
-3.34 does not match expected 3.34 to abs. tol. 1e-12 (abs. err 1e-06)
+3.34 != 3.34 to abs. tol. 1e-12 (abs. err 1e-06)
 Output line 11 did not match line 11 in expected output:
-1.00001 does not match expected 1 to abs. tol. 1e-12 (abs. err 1e-05)
+1.00001 != 1 to abs. tol. 1e-12 (abs. err 1e-05)
 [36m[Report for both_tols_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/sciath.job-0-both_tols_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
-2 does not match expected 2 to abs. tol. 1e-99 (abs. err 2e-06)
-2 does not match expected 2 to rel. tol. 1e-10 (rel. err. 9.99999e-07)
+2 != 2 to abs. tol. 1e-99 (abs. err 2e-06) or rel. tol 1e-10 (rel. err 9.99999e-07)
 Output line 5 did not match line 5 in expected output:
-1.0001 does not match expected 1.0002 to abs. tol. 1e-99 (abs. err 0.0001)
-1.0001 does not match expected 1.0002 to rel. tol. 1e-10 (rel. err. 9.998e-05)
+1.0001 != 1.0002 to abs. tol. 1e-99 (abs. err 0.0001) or rel. tol 1e-10 (rel. err 9.998e-05)
 Output line 8 did not match line 8 in expected output:
-3.34 does not match expected 3.34 to abs. tol. 1e-99 (abs. err 1e-06)
-3.34 does not match expected 3.34 to rel. tol. 1e-10 (rel. err. 2.99401e-07)
+3.34 != 3.34 to abs. tol. 1e-99 (abs. err 1e-06) or rel. tol 1e-10 (rel. err 2.99401e-07)
 Output line 11 did not match line 11 in expected output:
-1e-14 does not match expected 1e-16 to abs. tol. 1e-99 (abs. err 9.9e-15)
-1e-14 does not match expected 1e-16 to rel. tol. 1e-10 (rel. err. 99)
-1.00001 does not match expected 1 to abs. tol. 1e-99 (abs. err 1e-05)
-1.00001 does not match expected 1 to rel. tol. 1e-10 (rel. err. 1e-05)
+1e-14 != 1e-16 to abs. tol. 1e-99 (abs. err 9.9e-15) or rel. tol 1e-10 (rel. err 99)
+1.00001 != 1 to abs. tol. 1e-99 (abs. err 1e-05) or rel. tol 1e-10 (rel. err 1e-05)
 [36m[Report for atol_zero_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/sciath.job-0-atol_zero_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
-2 does not match expected 2 to abs. tol. 0 (abs. err 2e-06)
+2 != 2 to abs. tol. 0 (abs. err 2e-06)
 Output line 5 did not match line 5 in expected output:
-1.0001 does not match expected 1.0002 to abs. tol. 0 (abs. err 0.0001)
+1.0001 != 1.0002 to abs. tol. 0 (abs. err 0.0001)
 Output line 8 did not match line 8 in expected output:
-3.34 does not match expected 3.34 to abs. tol. 0 (abs. err 1e-06)
+3.34 != 3.34 to abs. tol. 0 (abs. err 1e-06)
 Output line 9 did not match line 9 in expected output:
-1e-100 does not match expected 0 to abs. tol. 0 (abs. err 1e-100)
+1e-100 != 0 to abs. tol. 0 (abs. err 1e-100)
 Output line 10 did not match line 10 in expected output:
-1.1e-100 does not match expected 1e-99 to abs. tol. 0 (abs. err 8.9e-100)
+1.1e-100 != 1e-99 to abs. tol. 0 (abs. err 8.9e-100)
 Output line 11 did not match line 11 in expected output:
-1e-14 does not match expected 1e-16 to abs. tol. 0 (abs. err 9.9e-15)
-1.00001 does not match expected 1 to abs. tol. 0 (abs. err 1e-05)
+1e-14 != 1e-16 to abs. tol. 0 (abs. err 9.9e-15)
+1.00001 != 1 to abs. tol. 0 (abs. err 1e-05)
 [36m[Report for rtol_zero_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/sciath.job-0-rtol_zero_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
-2 does not match expected 2 to rel. tol. 0 (rel. err. 9.99999e-07)
+2 != 2 to rel. tol. 0 (rel. err. 9.99999e-07)
 Output line 5 did not match line 5 in expected output:
-1.0001 does not match expected 1.0002 to rel. tol. 0 (rel. err. 9.998e-05)
+1.0001 != 1.0002 to rel. tol. 0 (rel. err. 9.998e-05)
 Output line 8 did not match line 8 in expected output:
-3.34 does not match expected 3.34 to rel. tol. 0 (rel. err. 2.99401e-07)
+3.34 != 3.34 to rel. tol. 0 (rel. err. 2.99401e-07)
 Output line 9 did not match line 9 in expected output:
-1e-100 does not match expected 0 to rel. tol. 0 (rel. err. inf)
+1e-100 != 0 to rel. tol. 0 (rel. err. inf)
 Output line 10 did not match line 10 in expected output:
-1.1e-100 does not match expected 1e-99 to rel. tol. 0 (rel. err. 0.89)
+1.1e-100 != 1e-99 to rel. tol. 0 (rel. err. 0.89)
 Output line 11 did not match line 11 in expected output:
-1e-14 does not match expected 1e-16 to rel. tol. 0 (rel. err. 99)
-1.00001 does not match expected 1 to rel. tol. 0 (rel. err. 1e-05)
+1e-14 != 1e-16 to rel. tol. 0 (rel. err. 99)
+1.00001 != 1 to rel. tol. 0 (rel. err. 1e-05)
 [36m[Report for both_tols_zero_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/sciath.job-0-both_tols_zero_fail.stdout
 Report for lines matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
-2 does not match expected 2 to abs. tol. 0 (abs. err 2e-06)
-2 does not match expected 2 to rel. tol. 0 (rel. err. 9.99999e-07)
+2 != 2 to abs. tol. 0 (abs. err 2e-06) or rel. tol 0 (rel. err 9.99999e-07)
 Output line 5 did not match line 5 in expected output:
-1.0001 does not match expected 1.0002 to abs. tol. 0 (abs. err 0.0001)
-1.0001 does not match expected 1.0002 to rel. tol. 0 (rel. err. 9.998e-05)
+1.0001 != 1.0002 to abs. tol. 0 (abs. err 0.0001) or rel. tol 0 (rel. err 9.998e-05)
 Output line 8 did not match line 8 in expected output:
-3.34 does not match expected 3.34 to abs. tol. 0 (abs. err 1e-06)
-3.34 does not match expected 3.34 to rel. tol. 0 (rel. err. 2.99401e-07)
+3.34 != 3.34 to abs. tol. 0 (abs. err 1e-06) or rel. tol 0 (rel. err 2.99401e-07)
 Output line 9 did not match line 9 in expected output:
-1e-100 does not match expected 0 to abs. tol. 0 (abs. err 1e-100)
-1e-100 does not match expected 0 to rel. tol. 0 (rel. err. inf)
+1e-100 != 0 to abs. tol. 0 (abs. err 1e-100) or rel. tol 0 (rel. err inf)
 Output line 10 did not match line 10 in expected output:
-1.1e-100 does not match expected 1e-99 to abs. tol. 0 (abs. err 8.9e-100)
-1.1e-100 does not match expected 1e-99 to rel. tol. 0 (rel. err. 0.89)
+1.1e-100 != 1e-99 to abs. tol. 0 (abs. err 8.9e-100) or rel. tol 0 (rel. err 0.89)
 Output line 11 did not match line 11 in expected output:
-1e-14 does not match expected 1e-16 to abs. tol. 0 (abs. err 9.9e-15)
-1e-14 does not match expected 1e-16 to rel. tol. 0 (rel. err. 99)
-1.00001 does not match expected 1 to abs. tol. 0 (abs. err 1e-05)
-1.00001 does not match expected 1 to rel. tol. 0 (rel. err. 1e-05)
+1e-14 != 1e-16 to abs. tol. 0 (abs. err 9.9e-15) or rel. tol 0 (rel. err 99)
+1.00001 != 1 to abs. tol. 0 (abs. err 1e-05) or rel. tol 0 (rel. err 1e-05)
 [35m[ *** Summary *** ][0m
 [91m[rtol_only_default_fail]  fail[0m (verification failed)
 [91m[rtol_only_fail]  fail[0m (verification failed)


### PR DESCRIPTION
Shorten report lines on mismatched numbers, and use a single line if
both absolute and relative tolerances fail.