### PR TITLE
Line Verifier: print number of expected matches in report

### DIFF
--- a/sciath/verifier_line.py
+++ b/sciath/verifier_line.py
@@ -36,7 +36,8 @@ class LineVerifier(ComparisonVerifier):
                 report.append('--- %s' % from_file)
                 report.append('+++ %s' % to_file)
             if rule_report:
-                report.append("Report for lines matching: '" + rule['re'] + "'")
+                report.append("Report for %d expected line(s) matching: '%s'"
+                              % (len(match_from), rule['re']))
                 report.extend(rule_report)
         return passing, report
 

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -11,7 +11,7 @@ echo 'The first number is 1.1\nThe second number is 1.01'
 [36m[Report for test][0m
 --- <<TEST DIR STRIPPED>>/test_data/harness5/test.expected
 +++ <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/job.stdout
-Report for lines matching: '^\s*The\ first\ number\ is'
+Report for 1 expected line(s) matching: '^\s*The\ first\ number\ is'
 Output line 1 did not match line 1 in expected output:
 1.1 != 7 to rel. tol. 1e-06 (rel. err. 0.842857)
 [35m[ *** Summary *** ][0m

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -17,7 +17,7 @@ printf 'a 34.3\nb43.3\n0.0\nx'
 [36m[Report for bar][0m
 --- ../test_data/module_line_verifier/bar.expected
 +++ <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/bar.stdout
-Report for lines matching: '^'
+Report for 3 expected line(s) matching: '^'
 Output line 3 did not match line 3 in expected output:
 Wrong number of values found: 1 instead of 0
 Wrong number of matched lines: 4 instead of 3

--- a/tests/test_data/verifier_line.expected
+++ b/tests/test_data/verifier_line.expected
@@ -6,7 +6,7 @@ printf 'should fail\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-1
 ['fail', 'verification failed']
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line2.stdout
-Report for lines matching: '  key'
+Report for 4 expected line(s) matching: '  key'
 Failure: Different numbers of matching lines found: 3 instead of 4
 [36m[Executing Line3][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
 printf '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 1.0 4.0\n  key 1e-12\n'
@@ -16,7 +16,7 @@ printf '  key 7.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n 
 ['fail', 'verification failed']
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line4.stdout
-Report for lines matching: '^\s*\ \ key'
+Report for 4 expected line(s) matching: '^\s*\ \ key'
 Output line 1 did not match line 1 in expected output:
 7 != 2 to rel. tol. 1e-06 (rel. err. 2.5)
 [36m[Executing Line5][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
@@ -24,6 +24,6 @@ printf '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n 
 ['fail', 'verification failed']
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line5.stdout
-Report for lines matching: '^\s*\ \ key'
+Report for 4 expected line(s) matching: '^\s*\ \ key'
 Output line 8 did not match line 8 in expected output:
 1e+12 != 1e-12 to rel. tol. 1e-06 (rel. err. 1e+24)

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -32,7 +32,7 @@ cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
 [36m[Report for rtol_only_default_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/rtol_only_default_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 5 did not match line 5 in expected output:
 1.0001 != 1.0002 to rel. tol. 1e-06 (rel. err. 9.998e-05)
 Output line 9 did not match line 9 in expected output:
@@ -45,7 +45,7 @@ Output line 11 did not match line 11 in expected output:
 [36m[Report for rtol_only_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/rtol_only_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 9 did not match line 9 in expected output:
 1e-100 != 0 to rel. tol. 0.001 (rel. err. inf)
 Output line 10 did not match line 10 in expected output:
@@ -55,7 +55,7 @@ Output line 11 did not match line 11 in expected output:
 [36m[Report for atol_only_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/atol_only_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
 2 != 2 to abs. tol. 1e-12 (abs. err 2e-06)
 Output line 5 did not match line 5 in expected output:
@@ -67,7 +67,7 @@ Output line 11 did not match line 11 in expected output:
 [36m[Report for both_tols_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/both_tols_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
 2 != 2 to abs. tol. 1e-99 (abs. err 2e-06) or rel. tol 1e-10 (rel. err 9.99999e-07)
 Output line 5 did not match line 5 in expected output:
@@ -80,7 +80,7 @@ Output line 11 did not match line 11 in expected output:
 [36m[Report for atol_zero_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/atol_zero_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
 2 != 2 to abs. tol. 0 (abs. err 2e-06)
 Output line 5 did not match line 5 in expected output:
@@ -97,7 +97,7 @@ Output line 11 did not match line 11 in expected output:
 [36m[Report for rtol_zero_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/rtol_zero_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
 2 != 2 to rel. tol. 0 (rel. err. 9.99999e-07)
 Output line 5 did not match line 5 in expected output:
@@ -114,7 +114,7 @@ Output line 11 did not match line 11 in expected output:
 [36m[Report for both_tols_zero_fail][0m
 --- ../test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/both_tols_zero_fail.stdout
-Report for lines matching: '^\s*key'
+Report for 11 expected line(s) matching: '^\s*key'
 Output line 2 did not match line 2 in expected output:
 2 != 2 to abs. tol. 0 (abs. err 2e-06) or rel. tol 0 (rel. err 9.99999e-07)
 Output line 5 did not match line 5 in expected output:


### PR DESCRIPTION
This is useful to give a quick idea of "how badly" a test failed
(e.g. did 1 of 100 matches fail, or did the single match fail?)