### PR TITLE
Launcher: return information when a job cannot be launched

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -158,9 +158,13 @@ class Harness:
                                         sentinel_file)
                     with open(sentinel_file, 'w'):
                         pass
-                self.launcher.submit_job(testrun.test.job,
-                                         output_path=testrun.output_path,
-                                         exec_path=testrun.exec_path)
+                success, info, report = self.launcher.submit_job(testrun.test.job,
+                                                                 output_path=testrun.output_path,
+                                                                 exec_path=testrun.exec_path)
+                if not success:
+                    testrun.status = _TestRunStatus.SKIPPED
+                    testrun.status_info = info
+                    testrun.report = report
 
 
     def print_all_tests(self):
@@ -316,6 +320,8 @@ class Harness:
         for testrun in self.testruns:
             if not testrun.active:
                 testrun.status = _TestRunStatus.DEACTIVATED
+                continue
+            if testrun.status == _TestRunStatus.SKIPPED:
                 continue
             if not sciath.launcher.job_launched(testrun.test.job, testrun.output_path):
                 testrun.status = _TestRunStatus.NOT_LAUNCHED

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -352,13 +352,16 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         return filename
 
     def submit_job(self, job, **kwargs):  #pylint: disable=too-many-locals,too-many-branches,too-many-statements
-        """ Run a job
+        """ Attempt to run a job
 
         Supply output_path to change the location where SciATH's output
         files will be saved.
 
         Supply exec_path to change the directory from which the command
         will be executed.
+
+        Returns a triple (success, info, report) describing if the launch
+        succeeded, and a summary string and full report, if appropriate.
         """
 
         output_path = os.getcwd()
@@ -393,11 +396,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
                 )
 
             if self.mpi_launch == 'none' and ranks != 1:
-                print(
-                    '[Failed to launch test \"' + job.name +
-                    '\" as test uses > 1 MPI ranks and no MPI launcher was provided]'
-                )
-                return
+                return False, 'MPI required', ['Not launched: requires MPI']
 
             command_resource = job.create_execute_command()
             launch_command = []
@@ -448,6 +447,8 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             _set_blocking_io_stdout()
             with open(os.path.join(output_path, job.launched_filename), 'w'):
                 pass
+
+        return True, None, None
 
     def clean(self, job, **kwargs):
         """ Remove all files created by the Launcher itself

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -5,9 +5,11 @@
   Version:           0.6.0
   Queue system:      none
   MPI launcher:      none
-[Failed to launch test "two_ranks" as test uses > 1 MPI ranks and no MPI launcher was provided]
+[35m[ *** Verification Reports *** ][0m
+[36m[Report for two_ranks][0m
+Not launched: requires MPI
 [35m[ *** Summary *** ][0m
-[33m[two_ranks]  not launched[0m
+[33m[two_ranks]  skipped[0m (MPI required)
 
 [91mFAILURE[0m
 


### PR DESCRIPTION
By having submit_job() return information, more elegantly deal
with the case where a test cannot be run due to lack of resources.
The Harness now uses this information to populate test run status
information, hopefully making it more clear what is going on when
doing something like trying to run an MPI test without an MPI-capable
Launcher.

Note that with test groups, the intended usage is that one should
explicitly exclude tests one does not actually want to run, hence global failure
is declared when tests are skipped for lack of resources.

closes #58