### PR TITLE
YAML file parsing: add mechanism to capture environment variables

### DIFF
--- a/tests/test_data/capture_environment.expected
+++ b/tests/test_data/capture_environment.expected
@@ -1,0 +1,21 @@
+[35m[ *** Cleanup *** ][0m
+[ -- Removing output for Test: a_test -- ]
+[35m[ *** Executing Tests *** ][0m
+[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+  Version:           0.6.0
+  Queue system:      none
+  MPI launcher:      none
+[36m[Executing a_test][0m from <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/sandbox
+printf 'defined var\n'
+echo defined var
+echo defined var longer
+echo
+echo <<TEST DIR STRIPPED>>/capture_environment_sandbox
+echo <<TEST DIR STRIPPED>>/test_data/capture_environment
+[35m[ *** Summary *** ][0m
+[32m[a_test]  pass[0m
+
+[32mSUCCESS[0m
+
+Report written to file:
+  <<TEST DIR STRIPPED>>/capture_environment_sandbox/sciath_test_report.txt

--- a/tests/test_data/capture_environment/tests.yml
+++ b/tests/test_data/capture_environment/tests.yml
@@ -1,0 +1,17 @@
+environment:
+  - DEFINED_VAR
+  - DEFINED_VAR_LONGER
+  - EMPTY_VAR
+  - PWD
+  # - UNDEFINED_VARIABLE
+tests:
+  - name: a_test
+    type: exit_code
+    commands:
+        - printf "$DEFINED_VAR\n"
+        - echo $DEFINED_VAR
+        - echo $DEFINED_VAR_LONGER
+        - echo $EMPTY_VAR
+        - echo $PWD
+        - echo HERE
+    expected: a_test.expected

--- a/tests/test_wrapper_with_vars.sh
+++ b/tests/test_wrapper_with_vars.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+export DEFINED_VAR="defined var"
+export DEFINED_VAR_LONGER="defined var longer"
+export EMPTY_VAR=
+
+sh test_wrapper.sh "$@"

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -128,3 +128,8 @@
   group: default_configuration
   command: sh test_wrapper.sh verify_exitcode "../test_data/verify_exitcode/input.yml"
   expected: test_data/verify_exitcode.expected
+-
+  name: capture_environment
+  group: default_configuration
+  command: sh test_wrapper_with_vars.sh capture_environment "../test_data/capture_environment/tests.yml"
+  expected: test_data/capture_environment.expected


### PR DESCRIPTION
Generalize the find-replace mechanism to replace multiple values,
and allow for a user-provided list of environment variables (required)
to substitue values for, when prepended with "$" in the input YAML file.

This provides a way to pass parameters to the otherwise-static YAML
input files. This could get confusing so is considered advanced usage.

It uses a naive replacement scheme. A better one might be as is done
here: https://gitlab.com/petsc/petsc/-/blob/master/src/docs/sphinx_docs/ext/html5_petsc.py#L203

closes #145 