### PR TITLE
Allow for blocking batch systems

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -321,7 +321,7 @@ class Harness:
         if args.update_expected:
             self.update_expected()
 
-        if args.execute or (not args.verify and self.launcher.use_batch):
+        if args.execute or (not args.verify and not self.launcher.blocking):
             if self.testruns:
                 print('[SciATH] Not verifying or reporting')
         else:

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -124,6 +124,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         self.queuing_system_type = []
         self.job_submission_command = []
         self.use_batch = False
+        self.blocking = None
         if conf_filename:
             self.conf_filename = conf_filename
         else:
@@ -307,21 +308,25 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             self.queuing_system_type = 'local'
             self.job_submission_command = ['sh']
             self.use_batch = True
+            self.blocking = True
 
         elif system_type in ['LSF', 'lsf']:
             self.queuing_system_type = 'lsf'
             self.job_submission_command = ['sh', '-c',
                                            'bsub < $0']  # This allows "<".
             self.use_batch = True
+            self.blocking = False
 
         elif system_type in ['SLURM', 'slurm']:
             self.queuing_system_type = 'slurm'
             self.job_submission_command = ['sbatch']
             self.use_batch = True
+            self.blocking = False
 
         elif system_type in ['none', 'None']:
             self.queuing_system_type = 'none'
             self.job_submission_command = ''
+            self.blocking = True
 
         else:
             raise RuntimeError(


### PR DESCRIPTION
And apply this to the "local" batch system, thus bringing it closer to being a replacement for the custom local execution mode as discussed in #48 

Also update the names of the local batch files to match the old behavior, which was missed in #177 