### PR TITLE
Always use a batch system

### DIFF
--- a/docs/_static/tutorial/failing_output.txt
+++ b/docs/_static/tutorial/failing_output.txt
@@ -3,11 +3,12 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [Executing failing] from /Users/patrick/scratch/failing_output/sandbox
-grep foo bar
+sh /Users/patrick/scratch/failing_output/failing.sh
 
 [ *** Verification Reports *** ]
 [Report for failing]

--- a/docs/_static/tutorial/first_and_second_output.txt
+++ b/docs/_static/tutorial/first_and_second_output.txt
@@ -4,13 +4,14 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [Executing first] from /Users/patrick/scratch/first_output/sandbox
-printf 'Hello, World!\n'
+sh /Users/patrick/scratch/first_output/first.sh
 [Executing second] from /Users/patrick/scratch/second_output/sandbox
-printf 'Hello Again, World!\n'
+sh /Users/patrick/scratch/second_output/second.sh
 
 [ *** Summary *** ]
 [first]  pass

--- a/docs/_static/tutorial/first_output.txt
+++ b/docs/_static/tutorial/first_output.txt
@@ -3,11 +3,12 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [Executing first] from /Users/patrick/scratch/first_output/sandbox
-printf 'Hello, World!\n'
+sh /Users/patrick/scratch/first_output/first.sh
 
 [ *** Summary *** ]
 [first]  pass

--- a/docs/_static/tutorial/text_diff_fail_output.txt
+++ b/docs/_static/tutorial/text_diff_fail_output.txt
@@ -3,11 +3,12 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [Executing text_diff] from /Users/patrick/scratch/text_diff_output/sandbox
-printf 'a line of text\n'
+sh /Users/patrick/scratch/text_diff_output/text_diff.sh
 
 [ *** Verification Reports *** ]
 [Report for text_diff]

--- a/docs/_static/tutorial/tutorial1_output.txt
+++ b/docs/_static/tutorial/tutorial1_output.txt
@@ -3,11 +3,12 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [Executing first] from /Users/patrick/scratch/first_output/sandbox
-printf 'Hello, World!\n'
+sh /Users/patrick/scratch/first_output/first.sh
 
 [ *** Summary *** ]
 [first]  pass

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -65,7 +65,7 @@ Execute the SciATH module to run the test
 
 You will be prompted to describe information about how to run jobs on your system.
 This tutorial can be used on a local machine or a cluster.
-To begin with, you may enter ``none`` for the first two questions.
+To begin with, enter ``local`` and ``none`` for the first two questions.
 
 This information is stored in a file called ``SciATHBatchQueuingSystem.conf``.
 
@@ -92,6 +92,7 @@ To (re-)verify your test results, without re-running the tests, use ``-v``:
 Take a look in the directory that was created, called ``first_output``.
 You will see several files and directories, including
 
+  * ``first.sh``, a shell script that was used to run your test
   * ``first.exitcode`` which contains the exitcode (``0``)
   * ``first.stdout`` which contains ``Hello, World!``
   * ``first.stderr``, which should be an empty file

--- a/sciath/__init__.py
+++ b/sciath/__init__.py
@@ -1,7 +1,7 @@
 """ SciATH: Scientific Application Test Harness """
 from sciath._sciath_io import NamedColors
 
-__version__ = (0, 8, 0)
+__version__ = (0, 9, 0)
 
 # A default set of colors
 SCIATH_COLORS = NamedColors()

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -111,7 +111,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             conf_file.write('patchVersion: %s\n' % patch)
             conf_file.write('queuingSystemType: local\n')
             conf_file.write('mpiLaunch: none\n')
-            conf_file.write('template: %s\n' %template_filename)
+            conf_file.write('template: %s\n' % template_filename)
 
     @staticmethod
     def write_default_template(system_type="local"):
@@ -124,7 +124,6 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         self.mpi_launch = []
         self.queuing_system_type = []
         self.job_submission_command = []
-        self.use_batch = False
         self.blocking = None
         if conf_filename:
             self.conf_filename = conf_filename
@@ -298,29 +297,21 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
 
     def set_queue_system_type(self, system_type):
         """ Set queueing system type and derived properties """
-        if system_type in ['sh', 'local', 'Local']:
+        if system_type in ['none', 'None', 'sh', 'local', 'Local']:
             self.queuing_system_type = 'local'
             self.job_submission_command = ['sh']
-            self.use_batch = True
             self.blocking = True
 
         elif system_type in ['LSF', 'lsf']:
             self.queuing_system_type = 'lsf'
             self.job_submission_command = ['sh', '-c',
                                            'bsub < $0']  # This allows "<".
-            self.use_batch = True
             self.blocking = False
 
         elif system_type in ['SLURM', 'slurm']:
             self.queuing_system_type = 'slurm'
             self.job_submission_command = ['sbatch']
-            self.use_batch = True
             self.blocking = False
-
-        elif system_type in ['none', 'None']:
-            self.queuing_system_type = 'none'
-            self.job_submission_command = ''
-            self.blocking = True
 
         else:
             raise RuntimeError(
@@ -334,15 +325,14 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         lines.append('  Version:           %d.%d.%d' % sciath.__version__)
         lines.append('  Queue system:      %s' % self.queuing_system_type)
         lines.append('  MPI launcher:      %s' % self.mpi_launch)
-        if self.use_batch:
-            lines.append('  Submit command:    %s' %
-                         command_join(self.job_submission_command))
-            if self.account_name:
-                lines.append('  Account:           %s' % self.account_name)
-            if self.queue_name:
-                lines.append('  Queue:             %s' % self.queue_name)
-            if self.queue_name:
-                lines.append('  Template:          %s' % self.template_filename)
+        lines.append('  Submit command:    %s' %
+                     command_join(self.job_submission_command))
+        if self.account_name:
+            lines.append('  Account:           %s' % self.account_name)
+        if self.queue_name:
+            lines.append('  Queue:             %s' % self.queue_name)
+        if self.queue_name:
+            lines.append('  Template:          %s' % self.template_filename)
         return '\n'.join(lines)
 
     def configure(self):  #pylint: disable=too-many-branches,too-many-statements
@@ -352,7 +342,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         print('Creating new configuration file ', self.conf_filename)
         user_input = None
         while not user_input:
-            prompt = '[1] Batch queuing system type <local,lsf,slurm,none>: '
+            prompt = '[1] Batch queuing system type <local,lsf,slurm>: '
             user_input = py23input(prompt)
             if not user_input:
                 print('Required.')
@@ -394,23 +384,19 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
                 ))
         self.set_mpi_launch(user_input)
 
-        if self.use_batch:
-            prompt = '[3] Account to charge (optional - hit enter if not applicable): '
-            self.account_name = py23input(prompt)
+        prompt = '[3] Account to charge (optional - hit enter if not applicable): '
+        self.account_name = py23input(prompt)
 
-            prompt = ('[4] Name of queue to submit tests to '
-                      '(optional - hit enter if not applicable): ')
-            self.queue_name = py23input(prompt)
+        prompt = ('[4] Name of queue to submit tests to '
+                  '(optional - hit enter if not applicable): ')
+        self.queue_name = py23input(prompt)
 
-            # Here, add questions about whether you want to override the default template
+        self.template_filename = self.write_default_template(
+            self.queuing_system_type)
 
-        # Always generate since there is not yet a way to override the default template
-        if self.queuing_system_type != 'none':
-            self.template_filename = self.write_default_template(
-                self.queuing_system_type)
-            print('** The template for generating batch submission files is\n')
-            print('**  ', self.template_filename)
-            print('**  You may modify it if desired\n')
+        print('** The template for generating batch submission files is\n')
+        print('**  ', self.template_filename)
+        print('**  You may modify it if desired\n')
 
         self._write_definition()
         print('\n')
@@ -437,10 +423,9 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             conf_file.write('queuingSystemType: %s\n' %
                             self.queuing_system_type)
             conf_file.write('mpiLaunch: %s\n' % self.mpi_launch)
-            if self.use_batch:
-                conf_file.write('accountName: %s\n' % self.account_name)
-                conf_file.write('queueName: %s\n' % self.queue_name)
-                conf_file.write('template: %s\n' % self.template_filename)
+            conf_file.write('accountName: %s\n' % self.account_name)
+            conf_file.write('queueName: %s\n' % self.queue_name)
+            conf_file.write('template: %s\n' % self.template_filename)
 
     def _load_definition(self):  #pylint: disable=too-many-branches
         major_file = None
@@ -458,13 +443,12 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
                 self.set_queue_system_type(data['queuingSystemType'])
             if 'mpiLaunch' in data:
                 self.set_mpi_launch(data['mpiLaunch'])
-            if self.use_batch:
-                if 'queueName' in data:
-                    self.queue_name = data['queueName']
-                if 'accountName' in data:
-                    self.account_name = data['accountName']
-                if 'template' in data:
-                    self.template_filename = data['template']
+            if 'queueName' in data:
+                self.queue_name = data['queueName']
+            if 'accountName' in data:
+                self.account_name = data['accountName']
+            if 'template' in data:
+                self.template_filename = data['template']
         except (IOError, OSError):  # Would be FileNotFoundError for Python >3.5
             # pylint: disable=bad-option-value,raise-missing-from
             raise SciATHLoadException(('[SciATH] Configuration file missing. '
@@ -517,72 +501,26 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
 
         _set_blocking_io_stdout()
 
-        if self.use_batch:
-            ranks = job.resource_max('ranks')
-            if self.mpi_launch == 'none' and ranks is not None and ranks != 1:
-                return False, 'MPI required', ['Not launched: requires MPI']
+        ranks = job.resource_max('ranks')
+        if self.mpi_launch == 'none' and ranks is not None and ranks != 1:
+            return False, 'MPI required', ['Not launched: requires MPI']
 
-            script_filename = self._create_launch_script(
-                job, output_path=output_path)
-            launch_command = self.job_submission_command + [script_filename]
+        script_filename = self._create_launch_script(job,
+                                                     output_path=output_path)
+        launch_command = self.job_submission_command + [script_filename]
 
-            print('%s[Executing %s]%s from %s' %
-                  (SCIATH_COLORS.subheader, job.name, SCIATH_COLORS.endc,
-                   exec_path))
-            print(command_join(launch_command))
+        print(
+            '%s[Executing %s]%s from %s' %
+            (SCIATH_COLORS.subheader, job.name, SCIATH_COLORS.endc, exec_path))
+        print(command_join(launch_command))
 
-            cwd_back = os.getcwd()
-            os.chdir(exec_path)
-            _subprocess_run(launch_command, universal_newlines=True)
-            os.chdir(cwd_back)
-            _set_blocking_io_stdout()
-            with open(os.path.join(output_path, job.launched_filename), 'w'):
-                pass
-        else:
-            mpi_launch = self.mpi_launch
-            ranks = job.resource_max('ranks')
-            threads = job.resource_max('threads')
-            if threads is not None and threads != 1:
-                raise ValueError(
-                    '[SciATH] Unsupported: Job cannot be submitted multi-threaded'
-                )
-
-            if self.mpi_launch == 'none' and ranks is not None and ranks != 1:
-                return False, 'MPI required', ['Not launched: requires MPI']
-
-            command_resource = job.create_execute_command()
-            launch_command = []
-            for command, resource in command_resource:
-                launch = []
-                if self.mpi_launch != 'none':
-                    j_ranks = resource["mpiranks"]
-                    launch += _format_mpi_launch_command(mpi_launch, j_ranks)
-                launch.extend(command)
-                launch_command.append(launch)
-
-            print('%s[Executing %s]%s from %s' %
-                  (SCIATH_COLORS.subheader, job.name, SCIATH_COLORS.endc,
-                   exec_path))
-            for term in launch_command:
-                print(command_join(term))
-
-            with open(os.path.join(output_path, job.exitcode_filename), 'w') as file_exitcode, \
-                 open(os.path.join(output_path, job.stderr_filename), 'w') as file_stderr, \
-                 open(os.path.join(output_path, job.stdout_filename), 'w') as file_stdout:
-                for command in launch_command:
-                    cwd_back = os.getcwd()
-                    os.chdir(exec_path)
-                    returncode = _subprocess_run(command,
-                                                 universal_newlines=True,
-                                                 stdout=file_stdout,
-                                                 stderr=file_stderr)
-                    os.chdir(cwd_back)
-                    file_exitcode.write(str(returncode) + "\n")
-                    _set_blocking_io_stdout()
-            with open(os.path.join(output_path, job.launched_filename), 'w'):
-                pass
-            with open(os.path.join(output_path, job.complete_filename), 'w'):
-                pass
+        cwd_back = os.getcwd()
+        os.chdir(exec_path)
+        _subprocess_run(launch_command, universal_newlines=True)
+        os.chdir(cwd_back)
+        _set_blocking_io_stdout()
+        with open(os.path.join(output_path, job.launched_filename), 'w'):
+            pass
 
         return True, None, None
 
@@ -610,9 +548,8 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         ]:
             _remove_file_if_it_exists(os.path.join(output_path, filename))
 
-        if self.use_batch:
-            filename = self._batch_filename(job)
-            _remove_file_if_it_exists(os.path.join(output_path, filename))
+        _remove_file_if_it_exists(
+            os.path.join(output_path, self._batch_filename(job)))
 
         _remove_file_if_it_exists(
             os.path.join(output_path, job.launched_filename))

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -104,16 +104,17 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         """ Writes a default configuration file """
         major, minor, patch = sciath.__version__
         conf_filename = conf_filename_in if conf_filename_in else Launcher._default_conf_filename
+        template_filename = Launcher.write_default_template()
         with open(conf_filename, 'w') as conf_file:
             conf_file.write('majorVersion: %s\n' % major)
             conf_file.write('minorVersion: %s\n' % minor)
             conf_file.write('patchVersion: %s\n' % patch)
-            conf_file.write('queuingSystemType: none\n')
+            conf_file.write('queuingSystemType: local\n')
             conf_file.write('mpiLaunch: none\n')
-            conf_file.write('template: none\n')
+            conf_file.write('template: %s\n' %template_filename)
 
     @staticmethod
-    def write_default_template(system_type):
+    def write_default_template(system_type="local"):
         """ Writes a default batch/queue system template for a limited set of system types """
         return _generate_default_template(system_type)
 

--- a/tests/test_data/capture_environment.expected
+++ b/tests/test_data/capture_environment.expected
@@ -3,16 +3,12 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing a_test][0m from <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/sandbox
-printf 'defined var\n'
-echo defined var
-echo defined var longer
-echo
-echo <<TEST DIR STRIPPED>>/capture_environment_sandbox
-echo <<TEST DIR STRIPPED>>/test_data/capture_environment
+sh <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/a_test.sh
 
 [35m[ *** Summary *** ][0m
 [32m[a_test]  pass[0m

--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -5,19 +5,16 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing testA][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/sandbox
-echo command 1 of 3
-echo command 2 of 3
-echo command 3 of 3
+sh <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/testA.sh
 [36m[Executing testA_too][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testA_too_output/sandbox
-echo command 1 of 3
-echo command 2 of 3
-echo command 3 of 3
+sh <<TEST DIR STRIPPED>>/groups_sandbox/testA_too_output/testA_too.sh
 [36m[Executing testE][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testE_output/sandbox
-echo testE
+sh <<TEST DIR STRIPPED>>/groups_sandbox/testE_output/testE.sh
 
 [35m[ *** Summary *** ][0m
 [32m[testA]  pass[0m

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -6,17 +6,18 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/sandbox
-echo 'Hello, I am Test #1'
+sh <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test2_output/sandbox
-printf 'Hello, I am Test #2\n'
+sh <<TEST DIR STRIPPED>>/harness1_sandbox/test2_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test3_output/sandbox
-touch test3.dat
+sh <<TEST DIR STRIPPED>>/harness1_sandbox/test3_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test4_output/sandbox
-grep foo bar
+sh <<TEST DIR STRIPPED>>/harness1_sandbox/test4_output/job.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for test4][0m

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -6,17 +6,18 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/sandbox
-echo 'Hello, I am Test #1'
+sh <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test2_output/sandbox
-printf 'Hello, I am Test #2\n'
+sh <<TEST DIR STRIPPED>>/harness2_sandbox/test2_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test3_output/sandbox
-touch test3.dat
+sh <<TEST DIR STRIPPED>>/harness2_sandbox/test3_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test4_output/sandbox
-grep foo bar
+sh <<TEST DIR STRIPPED>>/harness2_sandbox/test4_output/job.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for test4][0m

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -4,13 +4,14 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/sandbox
-echo 'Hello, I am Test #1'
+sh <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness3_sandbox/test2_output/sandbox
-printf 'Hello, I am Test #2\n'
+sh <<TEST DIR STRIPPED>>/harness3_sandbox/test2_output/job.sh
 
 [35m[ *** Summary *** ][0m
 [32m[test1]  pass[0m

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -9,23 +9,24 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/foo.sh
 [36m[Executing foo2][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo2_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo2_output/foo2.sh
 [36m[Executing foo_fail][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/sandbox
-echo foox
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/foo_fail.sh
 [36m[Executing missing][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/sandbox
-echo missing
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/missing.sh
 [36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/many_words_output/sandbox
-echo 'many words'
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/many_words_output/many_words.sh
 [36m[Executing comp_file][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_output/sandbox
-sh -c 'echo qux > compare_me.txt'
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_output/comp_file.sh
 [36m[Executing comp_file_fail][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/sandbox
-sh -c 'echo qux > compare_me.txt'
+sh <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/comp_file_fail.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for foo_fail][0m

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -3,11 +3,12 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/sandbox
-echo 'The first number is 1.1\nThe second number is 1.01'
+sh <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/job.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for test][0m

--- a/tests/test_data/harness5/test5.py
+++ b/tests/test_data/harness5/test5.py
@@ -10,7 +10,7 @@ import sciath.verifier_line
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
-command = ['echo', 'The first number is 1.1\nThe second number is 1.01']
+command = ['printf', 'The first number is 1.1\nThe second number is 1.01\n']
 task = sciath.task.Task(command)
 job = sciath.job.Job(task)
 test = sciath.test.Test(job, 'test')

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -9,23 +9,24 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/foo.sh
 [36m[Executing foo2][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo2_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo2_output/foo2.sh
 [36m[Executing foo_fail][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/sandbox
-echo foox
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/foo_fail.sh
 [36m[Executing missing][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/sandbox
-echo missing
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/missing.sh
 [36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/many_words_output/sandbox
-echo 'many words'
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/many_words_output/many_words.sh
 [36m[Executing comp_file][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_output/sandbox
-sh -c 'echo qux > compare_me.txt'
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_output/comp_file.sh
 [36m[Executing comp_file_fail][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/sandbox
-sh -c 'echo qux > compare_me.txt'
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/comp_file_fail.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for foo_fail][0m

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -5,15 +5,16 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/foo.sh
 [36m[Executing foo_again][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_again_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_again_output/foo_again.sh
 [36m[Executing bar][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/sandbox
-printf 'a 34.3\nb43.3\n0.0\nx'
+sh <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/bar.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for bar][0m

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -5,19 +5,16 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing testA][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/sandbox
-echo command 1 of 3
-echo command 2 of 3
-echo command 3 of 3
+sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/testA.sh
 [36m[Executing testA_too][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_too_output/sandbox
-echo command 1 of 3
-echo command 2 of 3
-echo command 3 of 3
+sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_too_output/testA_too.sh
 [36m[Executing testB][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testB_output/sandbox
-echo testB
+sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testB_output/testB.sh
 
 [35m[ *** Summary *** ][0m
 [32m[testA]  pass[0m

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -3,11 +3,12 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing relpath_test][0m from <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/sandbox
-sh <<TEST DIR STRIPPED>>/test_data/module_relpath/script.sh <<TEST DIR STRIPPED>>/test_data/module_relpath/data.txt
+sh <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/relpath_test.sh
 
 [35m[ *** Summary *** ][0m
 [32m[relpath_test]  pass[0m

--- a/tests/test_data/mpi_smoke_execute.expected
+++ b/tests/test_data/mpi_smoke_execute.expected
@@ -3,9 +3,10 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.7.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
+  Submit command:    sh
 [36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/sandbox
-/Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n 1 echo foo
+sh <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/two_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/mpi_smoke_two_ranks_execute.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_execute.expected
@@ -3,9 +3,10 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.7.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
+  Submit command:    sh
 [36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/sandbox
-/Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n 2 echo foo
+sh <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/two_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -3,9 +3,10 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for two_ranks][0m

--- a/tests/test_data/test1.expected
+++ b/tests/test_data/test1.expected
@@ -1,14 +1,14 @@
 [36m[Executing Test_1][0m from <<TEST DIR STRIPPED>>/test1_sandbox
-echo "aBc"; echo"kspits=30" 'echo ""'
+sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_1.sh
 [Test_1] True None
 [36m[Executing Test_2][0m from <<TEST DIR STRIPPED>>/test1_sandbox
-echo "aBc"; echo"kspits=30"
+sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_2.sh
 [Test_2] True None
 [36m[Executing Test_3][0m from <<TEST DIR STRIPPED>>/test1_sandbox
-echo "aBc"; echo"kspits=30"
+sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_3.sh
 [Test_3] False None
 [ExitCodeDiff] Expected exit code(s): [1]
 [ExitCodeDiff] Output exit code(s)  : [0]
 [36m[Executing Test_4][0m from <<TEST DIR STRIPPED>>/test1_sandbox
-echo "aBc"; echo"kspits=30"
+sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_4.sh
 [Test_4] True None

--- a/tests/test_data/test1/test_ex1.py
+++ b/tests/test_data/test1/test_ex1.py
@@ -20,7 +20,7 @@ def test_print(test, output_path):
 
 # Default verifier (check error code)
 def test1():  # result: pass
-    cmd = ['echo', '"aBc";', 'echo' '"kspits=30"', 'echo ""']
+    cmd = ['printf', '"aBc\nkspits=30\n"']
 
     t = Test(Job(Task(cmd), 'Test_1'))
     job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
@@ -30,7 +30,7 @@ def test1():  # result: pass
 
 
 def test2():  # result: pass
-    cmd = ['echo', '"aBc";', 'echo' '"kspits=30"']
+    cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_2'))
     job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
@@ -40,7 +40,7 @@ def test2():  # result: pass
 
 
 def test3():  # result: fail
-    cmd = ['echo', '"aBc";', 'echo' '"kspits=30"']
+    cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_3'))
     t.verifier.set_exit_codes_success([1])
@@ -51,7 +51,7 @@ def test3():  # result: fail
 
 
 def test4():  # result: pass
-    cmd = ['echo', '"aBc";', 'echo' '"kspits=30"']
+    cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_4'))
     job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
@@ -80,11 +80,9 @@ def main():
     t4 = test4()
     t4.verify(output_path=OUTPUT_PATH)
     test_print(t4, output_path=OUTPUT_PATH)
-    job_launcher.clean(t4.job, output_path=OUTPUT_PATH)
 
-    tests = [t1, t2, t3, t4]
-    for t in tests:
-        job_launcher.clean(t.job, output_path=OUTPUT_PATH)
+    # test cleaning up after one job
+    job_launcher.clean(t1.job, output_path=OUTPUT_PATH)
 
 
 main()

--- a/tests/test_data/test2.expected
+++ b/tests/test_data/test2.expected
@@ -1,8 +1,8 @@
 [36m[Executing Test_1_ud][0m from <<TEST DIR STRIPPED>>/test2_sandbox/output
-sh <<TEST DIR STRIPPED>>/test_data/test2/write_test1_ud.sh
+sh <<TEST DIR STRIPPED>>/test2_sandbox/output/Test_1_ud.sh
 [Test_1_ud] True None
 [36m[Executing Test_2_ud][0m from <<TEST DIR STRIPPED>>/test2_sandbox/output
-sh <<TEST DIR STRIPPED>>/test_data/test2/write_test2_ud.sh
+sh <<TEST DIR STRIPPED>>/test2_sandbox/output/Test_2_ud.sh
 [Test_2_ud] False None
 --- <<TEST DIR STRIPPED>>/test_data/test2/t1.expected
 +++ <<TEST DIR STRIPPED>>/test2_sandbox/output/Test_2_ud.stdout

--- a/tests/test_data/verifier_line.expected
+++ b/tests/test_data/verifier_line.expected
@@ -1,9 +1,9 @@
 [36m[Executing Line1][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-printf '  key 1.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-12\n'
+sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line1.sh
 True
 None
 [36m[Executing Line2][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-printf 'should fail\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 3.0 4.0\n  key 1e-12\n'
+sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line2.sh
 False
 None
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
@@ -11,11 +11,11 @@ None
 Report for 4 expected line(s) matching: '  key'
 Failure: Different numbers of matching lines found: 3 instead of 4
 [36m[Executing Line3][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-printf '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e-10 1.0 4.0\n  key 1e-12\n'
+sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line3.sh
 True
 None
 [36m[Executing Line4][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-printf '  key 7.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e-12\n'
+sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line4.sh
 False
 None
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
@@ -24,7 +24,7 @@ Report for 4 expected line(s) matching: '^\s*\ \ key'
 Output line 1 did not match line 1 in expected output:
 7 != 2 to rel. tol. 1e-06 (rel. err. 2.5)
 [36m[Executing Line5][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-printf '  key 2.0 2 -3.4 1e10\nx\n\n  key 1.0\n  key  \nkey\nkey 1e10 1.0 4.0\n  key 1e+12\n'
+sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line5.sh
 False
 None
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -10,25 +10,26 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing rtol_only_default_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/rtol_only_default_fail.sh
 [36m[Executing rtol_only_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/rtol_only_fail.sh
 [36m[Executing atol_only_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/atol_only_fail.sh
 [36m[Executing both_tols_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/both_tols_fail.sh
 [36m[Executing atol_zero_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/atol_zero_fail.sh
 [36m[Executing rtol_zero_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/rtol_zero_fail.sh
 [36m[Executing both_tols_zero_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/both_tols_zero_fail.sh
 [36m[Executing both_tols_pass][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_pass_output/sandbox
-cat <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/cat_me
+sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_pass_output/both_tols_pass.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for rtol_only_default_fail][0m

--- a/tests/test_data/verifier_line_order.expected
+++ b/tests/test_data/verifier_line_order.expected
@@ -3,11 +3,12 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing run][0m from <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/sandbox
-sh <<TEST DIR STRIPPED>>/test_data/verifier_line_order/run.sh
+sh <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/run.sh
 
 [35m[ *** Summary *** ][0m
 [32m[run]  pass[0m

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -3,11 +3,12 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for foo][0m
@@ -35,11 +36,12 @@ Report written to file:
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 [35m[ *** Updating Expected Output *** ][0m
 [ -- Updating output for Test: foo -- ]
 
@@ -55,11 +57,12 @@ Report written to file:
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
-echo foo
+sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 
 [35m[ *** Summary *** ][0m
 [32m[foo]  pass[0m

--- a/tests/test_data/verify_exitcode.expected
+++ b/tests/test_data/verify_exitcode.expected
@@ -8,25 +8,22 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
-  Version:           0.8.0
-  Queue system:      none
+  Version:           0.9.0
+  Queue system:      local
   MPI launcher:      none
+  Submit command:    sh
 [36m[Executing should_pass][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/sandbox
-true
+sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/should_pass.sh
 [36m[Executing should_fail][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_output/sandbox
-false
+sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_output/should_fail.sh
 [36m[Executing should_pass_multi][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_multi_output/sandbox
-true
-true
+sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_multi_output/should_pass_multi.sh
 [36m[Executing should_fail_multi][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi_output/sandbox
-true
-false
+sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi_output/should_fail_multi.sh
 [36m[Executing should_fail_multi2][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi2_output/sandbox
-false
-false
+sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi2_output/should_fail_multi2.sh
 [36m[Executing should_fail_multi3][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi3_output/sandbox
-false
-true
+sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi3_output/should_fail_multi3.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for should_fail][0m


### PR DESCRIPTION
Remove the local, "none" configuration for the Launcher, using the local batch system (which blocks as it submits shell scripts) instead.

Closes #48 