### PR TITLE
Launcher: change configuration file name

### DIFF
--- a/docs/_static/tutorial/failing_output.txt
+++ b/docs/_static/tutorial/failing_output.txt
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: failing -- ]
 
 [ *** Executing Tests *** ]
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/docs/_static/tutorial/first_and_second_output.txt
+++ b/docs/_static/tutorial/first_and_second_output.txt
@@ -3,7 +3,7 @@
 [ -- Removing output for Test: second -- ]
 
 [ *** Executing Tests *** ]
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/docs/_static/tutorial/first_output.txt
+++ b/docs/_static/tutorial/first_output.txt
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: first -- ]
 
 [ *** Executing Tests *** ]
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/docs/_static/tutorial/text_diff_fail_output.txt
+++ b/docs/_static/tutorial/text_diff_fail_output.txt
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: text_diff -- ]
 
 [ *** Executing Tests *** ]
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/docs/_static/tutorial/tutorial1_output.txt
+++ b/docs/_static/tutorial/tutorial1_output.txt
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: first -- ]
 
 [ *** Executing Tests *** ]
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -67,7 +67,7 @@ You will be prompted to describe information about how to run jobs on your syste
 This tutorial can be used on a local machine or a cluster.
 To begin with, enter ``local`` and ``none`` for the first two questions.
 
-This information is stored in a file called ``SciATHBatchQueuingSystem.conf``.
+This information is stored in a file called ``SciATH_launcher.conf``.
 
 Once you've defined this information, you'll see output like the following
 

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -97,7 +97,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
     not the status of any particular "run" of a :class:`Job`.
     """
 
-    _default_conf_filename = 'SciATHBatchQueuingSystem.conf'
+    _default_conf_filename = 'SciATH_launcher.conf'
 
     @staticmethod
     def write_default_definition(conf_filename_in=None):

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -9,7 +9,7 @@ if [ ! -f "$minisciath" ]; then
   exit 1
 fi
 
-if [ ! -f "SciATHBatchQueuingSystem.conf" ]; then
+if [ ! -f "SciATH_launcher.conf" ]; then
   python -m sciath  # prompt to generate configuration file
 fi
 

--- a/tests/test_data/capture_environment.expected
+++ b/tests/test_data/capture_environment.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: a_test -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -4,7 +4,7 @@
 [ -- Removing output for Test: testE -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -5,7 +5,7 @@
 [ -- Removing output for Test: test4 -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -5,7 +5,7 @@
 [ -- Removing output for Test: test4 -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -3,7 +3,7 @@
 [ -- Removing output for Test: test2 -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -8,7 +8,7 @@
 [ -- Removing output for Test: comp_file_fail -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: test -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -8,7 +8,7 @@
 [ -- Removing output for Test: comp_file_fail -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -4,7 +4,7 @@
 [ -- Removing output for Test: bar -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -4,7 +4,7 @@
 [ -- Removing output for Test: testB -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: relpath_test -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/mpi_smoke_execute.expected
+++ b/tests/test_data/mpi_smoke_execute.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: two_ranks -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>

--- a/tests/test_data/mpi_smoke_two_ranks_execute.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_execute.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: two_ranks -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: two_ranks -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -9,7 +9,7 @@
 [ -- Removing output for Test: both_tols_pass -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/verifier_line_order.expected
+++ b/tests/test_data/verifier_line_order.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: run -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -2,7 +2,7 @@
 [ -- Removing output for Test: foo -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none
@@ -35,7 +35,7 @@ Report written to file:
 [ -- Removing output for Test: foo -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none
@@ -56,7 +56,7 @@ Report written to file:
 [ -- Removing output for Test: foo -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_data/verify_exitcode.expected
+++ b/tests/test_data/verify_exitcode.expected
@@ -7,7 +7,7 @@
 [ -- Removing output for Test: should_fail_multi3 -- ]
 
 [35m[ *** Executing Tests *** ][0m
-[SciATH] Batch queueing system configuration [SciATHBatchQueuingSystem.conf]
+[SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.9.0
   Queue system:      local
   MPI launcher:      none

--- a/tests/test_mpi_wrapper.sh
+++ b/tests/test_mpi_wrapper.sh
@@ -6,7 +6,7 @@ sandbox="$test_name""_sandbox/"
 prereq_test_name=${3:-}
 prereq_sandbox="$prereq_test_name""_sandbox/"
 args=$2
-configuration_file=SciATHBatchQueuingSystem.conf
+configuration_file=SciATH_launcher.conf
 python=python
 
 if [ ! -f "$configuration_file" ]; then


### PR DESCRIPTION
This name is

- shorter
- more descriptive of the fact that the configuration pertains
  exclusively to the launcher
- similar in form to the template filename