### PR TITLE
Refactor launch config helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ branches:
 stages:
     - lint errors
     - test
-    - lint all
-    - format
+    - style
 
 jobs:
   include:
@@ -59,7 +58,7 @@ jobs:
       install:
         - pip install pylint
       script: sh -c "pylint --errors-only sciath/*.py tests/test_data/*/*.py"
-    - stage: lint all
+    - stage: style
       python: 3.9
       install:
         - pip install pylint
@@ -69,7 +68,7 @@ jobs:
         # versions of pylint, or can't be disable locally (duplicate-code,
         # see https://github.com/PyCQA/pylint/issues/214).
         - sh -c "pylint --disable=consider-using-f-string,unspecified-encoding,duplicate-code sciath/*.py"
-    - stage: format
+    - stage: style
       python: 3.9
       install:
         - pip install yapf

--- a/sciath/_conf_wizard.py
+++ b/sciath/_conf_wizard.py
@@ -5,7 +5,11 @@ import os
 from sciath._sciath_io import py23input
 
 
-def _query_user(description="", options=None, examples=None, default=None, validate=None):
+def _query_user(description="",
+                options=None,
+                examples=None,
+                default=None,
+                validate=None):
     valid = False
     while not valid:
         options_string = "" if options is None else " <%s>" % ", ".join(options)
@@ -56,29 +60,35 @@ def _launcher_interactive_configure(launcher):
     petsc_dir = os.getenv("PETSC_DIR")
     petsc_arch = os.getenv("PETSC_ARCH")
     if petsc_dir and petsc_arch:
-        mpi_launch_examples.append("  Current PETSc MPI wrapper : %s -n <ranks>" %
-                                   os.path.join(petsc_dir, petsc_arch, "bin", "mpiexec"))
+        mpi_launch_examples.append(
+            "  Current PETSc MPI wrapper : %s -n <ranks>" %
+            os.path.join(petsc_dir, petsc_arch, "bin", "mpiexec"))
     else:
         mpi_launch_examples.append(
-            "  Example PETSc MPI wrapper : /users/myname/petsc/arch-xxx/bin/mpiexec -n <ranks>")
+            "  Example PETSc MPI wrapper : /users/myname/petsc/arch-xxx/bin/mpiexec -n <ranks>"
+        )
 
-    mpi_launch = _query_user("\n[2] MPI launch command, including <ranks> for number of ranks",
-                             examples=mpi_launch_examples,
-                             default="none",
-                             validate=launcher.is_valid_mpi_launch)
+    mpi_launch = _query_user(
+        "\n[2] MPI launch command, including <ranks> for number of ranks",
+        examples=mpi_launch_examples,
+        default="none",
+        validate=launcher.is_valid_mpi_launch)
 
     launcher.set_mpi_launch(mpi_launch)
 
     launcher.account_name = _query_user("\n[3] Account to charge", default="")
 
-    launcher.queue_name = _query_user("\n[4] Name of queue to submit tests to", default="")
+    launcher.queue_name = _query_user("\n[4] Name of queue to submit tests to",
+                                      default="")
 
-    launcher.template_filename = launcher.write_default_template(launcher.queuing_system_type)
+    launcher.template_filename = launcher.write_default_template(
+        launcher.queuing_system_type)
 
     launcher.write_definition(launcher.conf_filename)
 
     print("")
-    print("** The template for batch submission files is  %s" % launcher.template_filename)
+    print("** The template for batch submission files is  %s" %
+          launcher.template_filename)
     print("** You may modify it if desired, but it will be overwritten")
     print("** if you re-configure.")
     print("")

--- a/sciath/_conf_wizard.py
+++ b/sciath/_conf_wizard.py
@@ -5,72 +5,84 @@ import os
 from sciath._sciath_io import py23input
 
 
+def _query_user(description="", options=None, examples=None, default=None, validate=None):
+    valid = False
+    while not valid:
+        options_string = "" if options is None else " <%s>" % ", ".join(options)
+
+        print("%s%s" % (description, options_string))
+        if examples is not None:
+            print("Examples:")
+            for example in examples:
+                print(example)
+
+        if default is not None:
+            print("Hit enter to accept default [%s]" % default)
+
+        result = py23input("> ")
+        result = os.path.expandvars(result)
+        result = os.path.expanduser(result)
+
+        if result == "":
+            result = default
+
+        valid = options is None or result in options
+        if validate is not None and valid:
+            valid = validate(result)
+
+    return result
+
+
 def _launcher_interactive_configure(launcher):
     """ Create a new configuration file from user input """
-    print('--------------------------------------------------------------')
-    print('Creating new configuration file ', launcher.conf_filename)
-    user_input = None
-    while not user_input:
-        prompt = '[1] Batch queuing system type <local,lsf,slurm>: '
-        user_input = py23input(prompt)
-        if not user_input:
-            print('Required.')
-        else:
-            try:
-                launcher.set_queue_system_type(user_input)
-            except RuntimeError as exception:
-                print(exception)
-                user_input = None
+    print("--------------------------------------------------------------")
+    print("Creating new configuration file %s" % launcher.conf_filename)
 
-    user_input = None
-    while not user_input:
-        prompt = ('[2] MPI launch command with num. procs. flag '
-                  '(required - hit enter for examples): ')
-        user_input = os.path.expandvars(py23input(prompt))
-        if not user_input:
-            print(' Required. Some example MPI launch commands:')
-            print('  No MPI Required           : none')
-            print('  Local Machine (mpirun)    : mpirun -np <ranks>')
-            print('  Local Machine (mpiexec)   : mpiexec -np <ranks>')
-            print('  SLURM w/ aprun            : aprun -B')
-            print('  Native SLURM              : srun -n $SLURM_NTASKS')
-            print('  LSF (Euler)               : mpirun')
-            petsc_dir = os.getenv('PETSC_DIR')
-            petsc_arch = os.getenv('PETSC_ARCH')
-            if petsc_dir and petsc_arch:
-                print('  Current PETSc MPI wrapper :',
-                      os.path.join(petsc_dir, petsc_arch, 'bin', 'mpiexec'),
-                      '-n <ranks>')
-            else:
-                print(
-                    ('  Example PETSc MPI wrapper : '
-                     '/users/myname/petsc/arch-xxx/bin/mpiexec -n <ranks>'))
-            print((' Note that the string \"<ranks>\" must be included if '
-                   'the number of ranks is required at launch.'))
-            print((
-                ' The keyword <ranks> will be replaced by the actual number '
-                'of MPI ranks (defined by a given test) when the test is launched.'
-            ))
-    launcher.set_mpi_launch(user_input)
+    launcher.set_queue_system_type(
+        _query_user(
+            "\n[1] Batch queuing system type",
+            options=["local", "lsf", "slurm"],
+            default="local",
+        ))
 
-    prompt = '[3] Account to charge (optional - hit enter if not applicable): '
-    launcher.account_name = py23input(prompt)
+    mpi_launch_examples = [
+        "  No MPI Required           : none",
+        "  Local Machine (mpirun)    : mpirun -np <ranks>",
+        "  Local Machine (mpiexec)   : mpiexec -np <ranks>",
+        "  SLURM w/ aprun            : aprun -B",
+        "  Native SLURM              : srun -n $SLURM_NTASKS",
+        "  LSF (Euler)               : mpirun",
+    ]
+    petsc_dir = os.getenv("PETSC_DIR")
+    petsc_arch = os.getenv("PETSC_ARCH")
+    if petsc_dir and petsc_arch:
+        mpi_launch_examples.append("  Current PETSc MPI wrapper : %s -n <ranks>" %
+                                   os.path.join(petsc_dir, petsc_arch, "bin", "mpiexec"))
+    else:
+        mpi_launch_examples.append(
+            "  Example PETSc MPI wrapper : /users/myname/petsc/arch-xxx/bin/mpiexec -n <ranks>")
 
-    prompt = ('[4] Name of queue to submit tests to '
-              '(optional - hit enter if not applicable): ')
-    launcher.queue_name = py23input(prompt)
+    mpi_launch = _query_user("\n[2] MPI launch command, including <ranks> for number of ranks",
+                             examples=mpi_launch_examples,
+                             default="none",
+                             validate=launcher.is_valid_mpi_launch)
 
-    launcher.template_filename = launcher.write_default_template(
-        launcher.queuing_system_type)
+    launcher.set_mpi_launch(mpi_launch)
 
-    print('** The template for generating batch submission files is\n')
-    print('**  ', launcher.template_filename)
-    print('**  You may modify it if desired\n')
+    launcher.account_name = _query_user("\n[3] Account to charge", default="")
 
-    launcher._write_definition()
-    print('\n')
-    print(
-        '** If you wish to change the config for your batch system, either')
-    print('**  (i) delete the file', launcher.conf_filename, ' or')
-    print('** (ii) re-run with the command line arg --configure')
-    print( '--------------------------------------------------------------')
+    launcher.queue_name = _query_user("\n[4] Name of queue to submit tests to", default="")
+
+    launcher.template_filename = launcher.write_default_template(launcher.queuing_system_type)
+
+    launcher.write_definition(launcher.conf_filename)
+
+    print("")
+    print("** The template for batch submission files is  %s" % launcher.template_filename)
+    print("** You may modify it if desired, but it will be overwritten")
+    print("** if you re-configure.")
+    print("")
+    print("** To change the config for your batch system, either")
+    print("**  (i) delete the file %s  or" % launcher.conf_filename)
+    print("** (ii) re-run with the command line arg --configure")
+    print("--------------------------------------------------------------")

--- a/sciath/_conf_wizard.py
+++ b/sciath/_conf_wizard.py
@@ -1,0 +1,76 @@
+""" Interactive tool for populating Launcher configuration information """
+
+import os
+
+from sciath._sciath_io import py23input
+
+
+def _launcher_interactive_configure(launcher):
+    """ Create a new configuration file from user input """
+    print('--------------------------------------------------------------')
+    print('Creating new configuration file ', launcher.conf_filename)
+    user_input = None
+    while not user_input:
+        prompt = '[1] Batch queuing system type <local,lsf,slurm>: '
+        user_input = py23input(prompt)
+        if not user_input:
+            print('Required.')
+        else:
+            try:
+                launcher.set_queue_system_type(user_input)
+            except RuntimeError as exception:
+                print(exception)
+                user_input = None
+
+    user_input = None
+    while not user_input:
+        prompt = ('[2] MPI launch command with num. procs. flag '
+                  '(required - hit enter for examples): ')
+        user_input = os.path.expandvars(py23input(prompt))
+        if not user_input:
+            print(' Required. Some example MPI launch commands:')
+            print('  No MPI Required           : none')
+            print('  Local Machine (mpirun)    : mpirun -np <ranks>')
+            print('  Local Machine (mpiexec)   : mpiexec -np <ranks>')
+            print('  SLURM w/ aprun            : aprun -B')
+            print('  Native SLURM              : srun -n $SLURM_NTASKS')
+            print('  LSF (Euler)               : mpirun')
+            petsc_dir = os.getenv('PETSC_DIR')
+            petsc_arch = os.getenv('PETSC_ARCH')
+            if petsc_dir and petsc_arch:
+                print('  Current PETSc MPI wrapper :',
+                      os.path.join(petsc_dir, petsc_arch, 'bin', 'mpiexec'),
+                      '-n <ranks>')
+            else:
+                print(
+                    ('  Example PETSc MPI wrapper : '
+                     '/users/myname/petsc/arch-xxx/bin/mpiexec -n <ranks>'))
+            print((' Note that the string \"<ranks>\" must be included if '
+                   'the number of ranks is required at launch.'))
+            print((
+                ' The keyword <ranks> will be replaced by the actual number '
+                'of MPI ranks (defined by a given test) when the test is launched.'
+            ))
+    launcher.set_mpi_launch(user_input)
+
+    prompt = '[3] Account to charge (optional - hit enter if not applicable): '
+    launcher.account_name = py23input(prompt)
+
+    prompt = ('[4] Name of queue to submit tests to '
+              '(optional - hit enter if not applicable): ')
+    launcher.queue_name = py23input(prompt)
+
+    launcher.template_filename = launcher.write_default_template(
+        launcher.queuing_system_type)
+
+    print('** The template for generating batch submission files is\n')
+    print('**  ', launcher.template_filename)
+    print('**  You may modify it if desired\n')
+
+    launcher._write_definition()
+    print('\n')
+    print(
+        '** If you wish to change the config for your batch system, either')
+    print('**  (i) delete the file', launcher.conf_filename, ' or')
+    print('** (ii) re-run with the command line arg --configure')
+    print( '--------------------------------------------------------------')

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -256,25 +256,26 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             with open(filename, 'r') as file:
                 self.template = file.readlines()
 
-    def set_mpi_launch(self, name):
-        """ Set the MPI launch command and check its form """
-        if name in ['none', 'None', '']:
-            name = 'none'
-        self.mpi_launch = name
-        # check for existence of "rank" keyword in the string "name"
-        if self.queuing_system_type in ['none', 'local'] and name != 'none':
-            keywordlist = ['<ranks>', '<cores>', '<tasks>', '<RANKS>']
-            # check of any of keywordlist[i] appears in name
-            valid_launcher = False
-            for kword in keywordlist:
-                if kword in name:
-                    valid_launcher = True
-                    break
+    def set_mpi_launch(self, mpi_launch):
+        """ Sets the MPI launch command and check its form """
+        if mpi_launch in [None, 'none', 'None', '']:
+            mpi_launch = 'none'
+        if not self.is_valid_mpi_launch(mpi_launch):
+            raise RuntimeError(
+                '[SciATH] MPI launch command must contain the keyword \"<ranks>\"'
+            )
+        self.mpi_launch = mpi_launch
 
-            if not valid_launcher:
-                raise RuntimeError(
-                    '[SciATH] Your MPI launch command must contain the keyword \"<ranks>\"'
-                )
+    def is_valid_mpi_launch(self, mpi_launch):
+        """ Returns whether a given string is acceptable to launch MPI jobs """
+        if mpi_launch == "none":
+            return True
+        if self.queuing_system_type in ['none', 'local']:
+            for keyword in ['<ranks>', '<cores>', '<tasks>', '<RANKS>']:
+                if keyword in mpi_launch:
+                    return True
+            return False
+        return True
 
     def set_queue_system_type(self, system_type):
         """ Set queueing system type and derived properties """
@@ -317,18 +318,20 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         return '\n'.join(lines)
 
     def configure(self):
+        """ Interactively configure the Launcher """
         _launcher_interactive_configure(self)
 
     def _setup(self):
         try:
-            self._load_definition()
+            self.load_definition(self.conf_filename)
         except SciATHLoadException:
             self.configure()
-            self._write_definition()
+            self.write_definition(self.conf_filename)
 
-    def _write_definition(self):
+    def write_definition(self, filename):
+        """ Writes configuration to a file """
         major, minor, patch = sciath.__version__
-        with open(self.conf_filename, 'w') as conf_file:
+        with open(filename, 'w') as conf_file:
             conf_file.write('majorVersion: %s\n' % major)
             conf_file.write('minorVersion: %s\n' % minor)
             conf_file.write('patchVersion: %s\n' % patch)
@@ -339,12 +342,13 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             conf_file.write('queueName: %s\n' % self.queue_name)
             conf_file.write('template: %s\n' % self.template_filename)
 
-    def _load_definition(self):  #pylint: disable=too-many-branches
+    def load_definition(self, filename):  #pylint: disable=too-many-branches
+        """ Loads configuration from a file """
         major_file = None
         minor_file = None
         patch_file = None
         try:
-            data = yaml_parse.parse_yaml_subset_from_file(self.conf_filename)
+            data = yaml_parse.parse_yaml_subset_from_file(filename)
             if 'majorVersion' in data:
                 major_file = int(data['majorVersion'])
             if 'minorVersion' in data:
@@ -365,7 +369,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             # pylint: disable=bad-option-value,raise-missing-from
             raise SciATHLoadException(('[SciATH] Configuration file missing. '
                                        'You must execute configure(), and/or '
-                                       '_write_definition() first'))
+                                       'write_definition() first'))
 
         major, minor = sciath.__version__[:2]
         if major_file is None or minor_file is None or patch_file is None:


### PR DESCRIPTION
This lays the groundwork to move the remaining information (launch command, blocking status) into the Launcher config (see #185), as it provides better support for defaults.