### PR TITLE
Launcher: remove internal notion of system type

### DIFF
--- a/docs/_static/tutorial/failing_output.txt
+++ b/docs/_static/tutorial/failing_output.txt
@@ -3,10 +3,11 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [Executing failing] from /Users/patrick/scratch/failing_output/sandbox
 sh /Users/patrick/scratch/failing_output/failing.sh
 

--- a/docs/_static/tutorial/first_and_second_output.txt
+++ b/docs/_static/tutorial/first_and_second_output.txt
@@ -4,10 +4,11 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [Executing first] from /Users/patrick/scratch/first_output/sandbox
 sh /Users/patrick/scratch/first_output/first.sh
 [Executing second] from /Users/patrick/scratch/second_output/sandbox

--- a/docs/_static/tutorial/first_output.txt
+++ b/docs/_static/tutorial/first_output.txt
@@ -3,10 +3,11 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [Executing first] from /Users/patrick/scratch/first_output/sandbox
 sh /Users/patrick/scratch/first_output/first.sh
 

--- a/docs/_static/tutorial/text_diff_fail_output.txt
+++ b/docs/_static/tutorial/text_diff_fail_output.txt
@@ -3,10 +3,11 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [Executing text_diff] from /Users/patrick/scratch/text_diff_output/sandbox
 sh /Users/patrick/scratch/text_diff_output/text_diff.sh
 

--- a/docs/_static/tutorial/tutorial1_output.txt
+++ b/docs/_static/tutorial/tutorial1_output.txt
@@ -3,10 +3,11 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [Executing first] from /Users/patrick/scratch/first_output/sandbox
 sh /Users/patrick/scratch/first_output/first.sh
 

--- a/sciath/__init__.py
+++ b/sciath/__init__.py
@@ -1,7 +1,7 @@
 """ SciATH: Scientific Application Test Harness """
 from sciath._sciath_io import NamedColors
 
-__version__ = (0, 9, 0)
+__version__ = (0, 10, 0)
 
 # A default set of colors
 SCIATH_COLORS = NamedColors()

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 import os
+import shlex
 import sys
 import fcntl
 import subprocess
@@ -105,25 +106,21 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         """ Writes a default configuration file """
         major, minor, patch = sciath.__version__
         conf_filename = conf_filename_in if conf_filename_in else Launcher._default_conf_filename
-        template_filename = Launcher.write_default_template()
+        template_filename = _generate_default_template("local")
         with open(conf_filename, 'w') as conf_file:
             conf_file.write('majorVersion: %s\n' % major)
             conf_file.write('minorVersion: %s\n' % minor)
             conf_file.write('patchVersion: %s\n' % patch)
-            conf_file.write('queuingSystemType: local\n')
+            conf_file.write('submitCommand: sh\n')
+            conf_file.write('blocking: True\n')
+            conf_file.write('jobLevelRanks: False\n')
             conf_file.write('mpiLaunch: none\n')
             conf_file.write('template: %s\n' % template_filename)
-
-    @staticmethod
-    def write_default_template(system_type="local"):
-        """ Writes a default batch/queue system template for a limited set of system types """
-        return _generate_default_template(system_type)
 
     def __init__(self, conf_filename=None):
         self.account_name = None
         self.queue_name = None
         self.mpi_launch = None
-        self.queuing_system_type = None
         self.job_submission_command = None
         self.has_job_level_ranks = None
         self.blocking = None
@@ -278,38 +275,11 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             return False
         return True
 
-    def set_queue_system_type(self, system_type):
-        """ Set queueing system type and derived properties """
-        if system_type in ['none', 'None', 'sh', 'local', 'Local']:
-            self.queuing_system_type = 'local'
-            self.job_submission_command = ['sh']
-            self.blocking = True
-            self.has_job_level_ranks = False
-
-        elif system_type in ['LSF', 'lsf']:
-            self.queuing_system_type = 'lsf'
-            self.job_submission_command = ['sh', '-c',
-                                           'bsub < $0']  # This allows "<".
-            self.blocking = False
-            self.has_job_level_ranks = True
-
-        elif system_type in ['SLURM', 'slurm']:
-            self.queuing_system_type = 'slurm'
-            self.job_submission_command = ['sbatch']
-            self.blocking = False
-            self.has_job_level_ranks = True
-
-        else:
-            raise RuntimeError(
-                '[SciATH] Unknown or unsupported batch queuing system "' +
-                system_type + '" specified')
-
     def __str__(self):
         lines = []
         lines.append('[SciATH] Batch queueing system configuration [%s]' %
                      self.conf_filename)
         lines.append('  Version:           %d.%d.%d' % sciath.__version__)
-        lines.append('  Queue system:      %s' % self.queuing_system_type)
         lines.append('  MPI launcher:      %s' % self.mpi_launch)
         lines.append('  Submit command:    %s' %
                      command_join(self.job_submission_command))
@@ -341,9 +311,8 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
             conf_file.write('majorVersion: %s\n' % major)
             conf_file.write('minorVersion: %s\n' % minor)
             conf_file.write('patchVersion: %s\n' % patch)
-            conf_file.write('queuingSystemType: %s\n' %
-                            self.queuing_system_type)
-            conf_file.write('submitCommand: %s\n' % command_join(self.job_submission_command))
+            conf_file.write('submitCommand: %s\n' %
+                            command_join(self.job_submission_command))
             conf_file.write('blocking: %s\n' % self.blocking)
             conf_file.write('jobLevelRanks: %s\n' % self.has_job_level_ranks)
             conf_file.write('mpiLaunch: %s\n' % self.mpi_launch)
@@ -364,8 +333,6 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
                 minor_file = int(data['minorVersion'])
             if 'patchVersion' in data:
                 patch_file = int(data['patchVersion'])
-            if 'queuingSystemType' in data:
-                self.set_queue_system_type(data['queuingSystemType'])
             if 'submitCommand' in data:
                 self.job_submission_command = shlex.split(data['submitCommand'])
             if 'blocking' in data:

--- a/tests/test_data/capture_environment.expected
+++ b/tests/test_data/capture_environment.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing a_test][0m from <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/sandbox
 sh <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/a_test.sh
 

--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -5,10 +5,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing testA][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/sandbox
 sh <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/testA.sh
 [36m[Executing testA_too][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testA_too_output/sandbox

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -6,10 +6,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test2_output/sandbox

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -6,10 +6,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test2_output/sandbox

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -4,10 +4,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/job.sh
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness3_sandbox/test2_output/sandbox

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -9,10 +9,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/foo.sh
 [36m[Executing foo2][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo2_output/sandbox

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/job.sh
 

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -9,10 +9,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/foo.sh
 [36m[Executing foo2][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo2_output/sandbox

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -5,10 +5,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/foo.sh
 [36m[Executing foo_again][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_again_output/sandbox

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -5,10 +5,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing testA][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/testA.sh
 [36m[Executing testA_too][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_too_output/sandbox

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing relpath_test][0m from <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/relpath_test.sh
 

--- a/tests/test_data/mpi_smoke_execute.expected
+++ b/tests/test_data/mpi_smoke_execute.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/sandbox
 sh <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/two_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/mpi_smoke_two_ranks_execute.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_execute.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/sandbox
 sh <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/two_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for two_ranks][0m

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -10,10 +10,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing rtol_only_default_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/rtol_only_default_fail.sh
 [36m[Executing rtol_only_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/sandbox

--- a/tests/test_data/verifier_line_order.expected
+++ b/tests/test_data/verifier_line_order.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing run][0m from <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/run.sh
 

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -3,10 +3,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 
@@ -36,10 +37,11 @@ Report written to file:
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 [35m[ *** Updating Expected Output *** ][0m
@@ -57,10 +59,11 @@ Report written to file:
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 

--- a/tests/test_data/verify_exitcode.expected
+++ b/tests/test_data/verify_exitcode.expected
@@ -8,10 +8,11 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.9.0
-  Queue system:      local
+  Version:           0.10.0
   MPI launcher:      none
   Submit command:    sh
+  Blocking:          True
+  Job-level ranks:   False
 [36m[Executing should_pass][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/should_pass.sh
 [36m[Executing should_fail][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_output/sandbox


### PR DESCRIPTION
Push the notion of system type out to the configuration helper.

This is crucial because we now have a rudimentary version of a user-extensible launching system.
The user is no longer constrained to system types defined by the Launcher. Rather, all information that was inferred from those types is now in the Launcher configuration and template, so by editing those files, one can run on any system, provided it conforms to the general workflow (process the template to create a submission file, and pass that file as an argument to some submission command).

Closes #185 