### PR TITLE
v0.11.0 Launcher: only use <ranks> as ranks placeholder

### DIFF
--- a/docs/_static/tutorial/failing_output.txt
+++ b/docs/_static/tutorial/failing_output.txt
@@ -3,7 +3,7 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/docs/_static/tutorial/first_and_second_output.txt
+++ b/docs/_static/tutorial/first_and_second_output.txt
@@ -4,7 +4,7 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/docs/_static/tutorial/first_output.txt
+++ b/docs/_static/tutorial/first_output.txt
@@ -3,7 +3,7 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/docs/_static/tutorial/text_diff_fail_output.txt
+++ b/docs/_static/tutorial/text_diff_fail_output.txt
@@ -3,7 +3,7 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/docs/_static/tutorial/tutorial1_output.txt
+++ b/docs/_static/tutorial/tutorial1_output.txt
@@ -3,7 +3,7 @@
 
 [ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/sciath/__init__.py
+++ b/sciath/__init__.py
@@ -1,7 +1,7 @@
 """ SciATH: Scientific Application Test Harness """
 from sciath._sciath_io import NamedColors
 
-__version__ = (0, 10, 0)
+__version__ = (0, 11, 0)
 
 # A default set of colors
 SCIATH_COLORS = NamedColors()

--- a/sciath/launcher.py
+++ b/sciath/launcher.py
@@ -38,11 +38,7 @@ def _formatted_split_time(seconds):
 
 
 def _format_mpi_launch_command(mpi_launch, ranks):
-    launch = mpi_launch
-    launch = launch.replace("<ranks>", str(ranks))
-    launch = launch.replace("<cores>", str(ranks))
-    launch = launch.replace("<tasks>", str(ranks))
-    launch = launch.replace("<RANKS>", str(ranks))
+    launch = mpi_launch.replace("<ranks>", str(ranks))
     return launch.split()
 
 
@@ -269,10 +265,7 @@ class Launcher:  #pylint: disable=too-many-instance-attributes
         if mpi_launch == "none":
             return True
         if not self.has_job_level_ranks:
-            for keyword in ['<ranks>', '<cores>', '<tasks>', '<RANKS>']:
-                if keyword in mpi_launch:
-                    return True
-            return False
+            return '<ranks>' in mpi_launch
         return True
 
     def __str__(self):

--- a/tests/test_data/capture_environment.expected
+++ b/tests/test_data/capture_environment.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -5,7 +5,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -6,7 +6,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -6,7 +6,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -4,7 +4,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -9,7 +9,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -9,7 +9,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -5,7 +5,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -5,7 +5,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/mpi_smoke_execute.expected
+++ b/tests/test_data/mpi_smoke_execute.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/mpi_smoke_two_ranks_execute.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_execute.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -10,7 +10,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/verifier_line_order.expected
+++ b/tests/test_data/verifier_line_order.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -3,7 +3,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
@@ -37,7 +37,7 @@ Report written to file:
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
@@ -59,7 +59,7 @@ Report written to file:
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True

--- a/tests/test_data/verify_exitcode.expected
+++ b/tests/test_data/verify_exitcode.expected
@@ -8,7 +8,7 @@
 
 [35m[ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
-  Version:           0.10.0
+  Version:           0.11.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True


### PR DESCRIPTION
Remove other synonyms for this, since we now check at the configuration
helper level.

Bump version since .conf files could have these other synonyms for the
MPI launch commands.