### PR TITLE
Harness, Launcher: move stdout output to Harness from Launcher

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -11,7 +11,7 @@ import sciath
 import sciath.launcher
 import sciath.test_file
 from sciath import SCIATH_COLORS
-from sciath._sciath_io import py23input
+from sciath._sciath_io import py23input, command_join
 
 
 class _TestRunStatus:  #pylint: disable=too-few-public-methods
@@ -165,6 +165,13 @@ class Harness:
                                         sentinel_file)
                     with open(sentinel_file, 'w'):
                         pass
+                print('%s[Executing %s]%s from %s' %
+                      (SCIATH_COLORS.subheader, testrun.test.job.name,
+                       SCIATH_COLORS.endc, testrun.exec_path))
+                print(
+                    command_join(
+                        self.launcher.launch_command(testrun.test.job,
+                                                     testrun.output_path)))
                 success, info, report = self.launcher.submit_job(
                     testrun.test.job,
                     output_path=testrun.output_path,

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -8,6 +8,8 @@
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
+[36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/sandbox
+sh <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/two_ranks.sh
 
 [35m[ *** Verification Reports *** ][0m
 [36m[Report for two_ranks][0m

--- a/tests/test_data/test1.expected
+++ b/tests/test_data/test1.expected
@@ -1,14 +1,14 @@
-[36m[Executing Test_1][0m from <<TEST DIR STRIPPED>>/test1_sandbox
+[Test_1] Executing from <<TEST DIR STRIPPED>>/test1_sandbox
 sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_1.sh
 [Test_1] True None
-[36m[Executing Test_2][0m from <<TEST DIR STRIPPED>>/test1_sandbox
+[Test_2] Executing from <<TEST DIR STRIPPED>>/test1_sandbox
 sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_2.sh
 [Test_2] True None
-[36m[Executing Test_3][0m from <<TEST DIR STRIPPED>>/test1_sandbox
+[Test_3] Executing from <<TEST DIR STRIPPED>>/test1_sandbox
 sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_3.sh
 [Test_3] False None
 [ExitCodeDiff] Expected exit code(s): [1]
 [ExitCodeDiff] Output exit code(s)  : [0]
-[36m[Executing Test_4][0m from <<TEST DIR STRIPPED>>/test1_sandbox
+[Test_4] Executing from <<TEST DIR STRIPPED>>/test1_sandbox
 sh <<TEST DIR STRIPPED>>/test1_sandbox/output/Test_4.sh
 [Test_4] True None

--- a/tests/test_data/test1/test_ex1.py
+++ b/tests/test_data/test1/test_ex1.py
@@ -6,12 +6,19 @@ from sciath.launcher import Launcher
 from sciath.test import Test
 from sciath.job import Job
 from sciath.task import Task
+from sciath._sciath_io import command_join
 
 OUTPUT_PATH = os.path.join(os.getcwd(), 'output')
+EXEC_PATH = os.getcwd()
 job_launcher = Launcher()
 
 
-def test_print(test, output_path):
+def test_print_pre(test, output_path, exec_path):
+    print("[%s] Executing from %s" % (test.job.name, exec_path))
+    print(command_join(job_launcher.launch_command(test.job, output_path)))
+
+
+def test_print_post(test, output_path):
     passing, info, report = test.verifier.execute(output_path=output_path)
     print('[%s] %r %s' % (test.name, passing, info))
     for line in report:
@@ -23,9 +30,10 @@ def test1():  # result: pass
     cmd = ['printf', '"aBc\nkspits=30\n"']
 
     t = Test(Job(Task(cmd), 'Test_1'))
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
+    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
     t.verify(output_path=OUTPUT_PATH)
-    test_print(t, output_path=OUTPUT_PATH)
+    test_print_post(t, output_path=OUTPUT_PATH)
     return t
 
 
@@ -33,9 +41,10 @@ def test2():  # result: pass
     cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_2'))
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
+    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
     t.verify(output_path=OUTPUT_PATH)
-    test_print(t, output_path=OUTPUT_PATH)
+    test_print_post(t, output_path=OUTPUT_PATH)
     return t
 
 
@@ -44,9 +53,10 @@ def test3():  # result: fail
 
     t = Test(Job(Task(cmd), 'Test_3'))
     t.verifier.set_exit_codes_success([1])
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
+    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
     t.verify(output_path=OUTPUT_PATH)
-    test_print(t, output_path=OUTPUT_PATH)
+    test_print_post(t, output_path=OUTPUT_PATH)
     return t
 
 
@@ -54,7 +64,8 @@ def test4():  # result: pass
     cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_4'))
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH)
+    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
     return t
 
 
@@ -79,10 +90,11 @@ def main():
     # test with staged submit/verify
     t4 = test4()
     t4.verify(output_path=OUTPUT_PATH)
-    test_print(t4, output_path=OUTPUT_PATH)
+    test_print_post(t4, output_path=OUTPUT_PATH)
 
-    # test cleaning up after one job
-    job_launcher.clean(t1.job, output_path=OUTPUT_PATH)
+    # Clean up after all jobs
+    for t in (t1, t2, t3, t4):
+        job_launcher.clean(t.job, output_path=OUTPUT_PATH)
 
 
 main()

--- a/tests/test_data/test2.expected
+++ b/tests/test_data/test2.expected
@@ -1,7 +1,7 @@
-[36m[Executing Test_1_ud][0m from <<TEST DIR STRIPPED>>/test2_sandbox/output
+[Test_1_ud] Executing from <<TEST DIR STRIPPED>>/test2_sandbox
 sh <<TEST DIR STRIPPED>>/test2_sandbox/output/Test_1_ud.sh
 [Test_1_ud] True None
-[36m[Executing Test_2_ud][0m from <<TEST DIR STRIPPED>>/test2_sandbox/output
+[Test_2_ud] Executing from <<TEST DIR STRIPPED>>/test2_sandbox
 sh <<TEST DIR STRIPPED>>/test2_sandbox/output/Test_2_ud.sh
 [Test_2_ud] False None
 --- <<TEST DIR STRIPPED>>/test_data/test2/t1.expected

--- a/tests/test_data/test2/test_ex2.py
+++ b/tests/test_data/test2/test_ex2.py
@@ -7,14 +7,21 @@ from sciath.test import Test
 from sciath.job import Job
 from sciath.task import Task
 from sciath.verifier import ComparisonVerifier
+from sciath._sciath_io import command_join
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
 OUTPUT_PATH = os.path.join(os.getcwd(), 'output')
+EXEC_PATH = os.getcwd()
 job_launcher = Launcher()
 
 
-def test_print(test, output_path):
+def test_print_pre(test, output_path, exec_path):
+    print("[%s] Executing from %s" % (test.job.name, exec_path))
+    print(command_join(job_launcher.launch_command(test.job, output_path)))
+
+
+def test_print_post(test, output_path):
     passing, info, report = test.verifier.execute(output_path=output_path)
     print('[%s] %r %s' % (test.name, passing, info))
     for line in report:
@@ -27,11 +34,12 @@ def test1_ud():  # result: pass
     t = Test(Job(Task(cmd), 'Test_1_ud'))
     t.verifier = ComparisonVerifier(t, os.path.join(this_dir, "t1.expected"))
 
+    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
     job_launcher.submit_job(t.job,
                             output_path=OUTPUT_PATH,
                             exec_path=OUTPUT_PATH)
     t.verify(output_path=OUTPUT_PATH)
-    test_print(t, output_path=OUTPUT_PATH)
+    test_print_post(t, output_path=OUTPUT_PATH)
     return t
 
 
@@ -41,11 +49,12 @@ def test2_ud():  # result: fail
     t = Test(Job(Task(cmd), 'Test_2_ud'))
     t.verifier = ComparisonVerifier(t, os.path.join(this_dir, "t1.expected"))
 
+    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
     job_launcher.submit_job(t.job,
                             output_path=OUTPUT_PATH,
                             exec_path=OUTPUT_PATH)
     t.verify(output_path=OUTPUT_PATH)
-    test_print(t, output_path=OUTPUT_PATH)
+    test_print_post(t, output_path=OUTPUT_PATH)
     return t
 
 

--- a/tests/test_data/verifier_line.expected
+++ b/tests/test_data/verifier_line.expected
@@ -1,21 +1,13 @@
-[36m[Executing Line1][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line1.sh
 True
 None
-[36m[Executing Line2][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line2.sh
 False
 None
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line2.stdout
 Report for 4 expected line(s) matching: '  key'
 Failure: Different numbers of matching lines found: 3 instead of 4
-[36m[Executing Line3][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line3.sh
 True
 None
-[36m[Executing Line4][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line4.sh
 False
 None
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected
@@ -23,8 +15,6 @@ None
 Report for 4 expected line(s) matching: '^\s*\ \ key'
 Output line 1 did not match line 1 in expected output:
 7 != 2 to rel. tol. 1e-06 (rel. err. 2.5)
-[36m[Executing Line5][0m from <<TEST DIR STRIPPED>>/verifier_line_sandbox
-sh <<TEST DIR STRIPPED>>/verifier_line_sandbox/output/Line5.sh
 False
 None
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line/expected


### PR DESCRIPTION
This enforces the intended behavior that only the Harness produces
output to stdout.

The is acheived by adding functions to the launcher to assemble the
command that will be used by submit_job() before it is called (required
since it may block). The harness then uses this function to print
the command that the Launcher will use.

Perhaps undesirable behavior: if a job is skipped
due to lack of MPI, a command is still printed, even though the
script named is never actually produced.

Partially addresses #27