### PR TITLE
Harness, file input: custom exception and handling at harness level

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -298,7 +298,14 @@ class Harness:
 
         if args.input_files:
             for input_file in args.input_files:
-                self.add_tests_from_file(input_file)
+                try:
+                    self.add_tests_from_file(input_file)
+                except sciath.test_file.SciATHTestFileException as exception:
+                    print(
+                        "%s[SciATH] Error:%s There was a problem reading tests from %s:"
+                        % (SCIATH_COLORS.fail, SCIATH_COLORS.endc, input_file))
+                    print(exception)
+                    return
 
         if args.list:
             self.print_all_tests()

--- a/sciath/yaml_parse.py
+++ b/sciath/yaml_parse.py
@@ -8,6 +8,10 @@
 from sciath.utility import DotDict
 
 
+class SciATHYAMLParseException(Exception):
+    """ Exception for a test file with invalid syntax """
+
+
 def parse_yaml_subset_from_file(filename):  #pylint: disable=too-many-branches,too-many-locals
     """ Parse a subset of YAML files into a nested structure of list and dict objects
 
@@ -98,8 +102,8 @@ def parse_yaml_subset_from_file(filename):  #pylint: disable=too-many-branches,t
 
 
 def _parse_error(filename, line_number, message):
-    raise Exception("[SciATH] %s:%d  File parse error: %s" %
-                    (filename, line_number, message))
+    raise SciATHYAMLParseException("%s:%d  File parse error: %s" %
+                                   (filename, line_number, message))
 
 
 def _compute_indent(string, filename, line_number):


### PR DESCRIPTION
Add custom Exceptions for errors reading the YAMl file (in general),
and the parsing of it into individual tests. The Harness should catch
these and exit gracefully, instead of presenting the user with an
uncaught exception.