### PR TITLE
Colors: add helper functions and better encapsulate

### DIFF
--- a/docs/_static/tutorial/failing_output.txt
+++ b/docs/_static/tutorial/failing_output.txt
@@ -1,24 +1,24 @@
-[ *** Cleanup *** ]
-[ -- Removing output for Test: failing -- ]
+[SciATH][ *** Cleanup *** ]
+[SciATH] Removing output for Test: failing
 
-[ *** Executing Tests *** ]
+[SciATH][ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[Executing failing] from /Users/patrick/scratch/failing_output/sandbox
+[SciATH][ Executing failing ]from /Users/patrick/scratch/failing_output/sandbox
 sh /Users/patrick/scratch/failing_output/failing.sh
 
-[ *** Verification Reports *** ]
-[Report for failing]
+[SciATH][ *** Verification Reports *** ]
+[SciATH][ Report for failing ]
 [ExitCodeDiff] Expected exit code(s): [0]
 [ExitCodeDiff] Output exit code(s)  : [2]
 check non-empty stderr file:
     less /Users/patrick/scratch/failing_output/failing.stderr
 
-[ *** Summary *** ]
+[SciATH][ *** Summary *** ]
 [first]  deactivated
 [second]  deactivated
 [failing]  fail

--- a/docs/_static/tutorial/first_and_second_output.txt
+++ b/docs/_static/tutorial/first_and_second_output.txt
@@ -1,20 +1,20 @@
-[ *** Cleanup *** ]
-[ -- Removing output for Test: first -- ]
-[ -- Removing output for Test: second -- ]
+[SciATH][ *** Cleanup *** ]
+[SciATH] Removing output for Test: first
+[SciATH] Removing output for Test: second
 
-[ *** Executing Tests *** ]
+[SciATH][ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[Executing first] from /Users/patrick/scratch/first_output/sandbox
+[SciATH][ Executing first ]from /Users/patrick/scratch/first_output/sandbox
 sh /Users/patrick/scratch/first_output/first.sh
-[Executing second] from /Users/patrick/scratch/second_output/sandbox
+[SciATH][ Executing second ]from /Users/patrick/scratch/second_output/sandbox
 sh /Users/patrick/scratch/second_output/second.sh
 
-[ *** Summary *** ]
+[SciATH][ *** Summary *** ]
 [first]  pass
 [second]  pass
 [failing]  deactivated

--- a/docs/_static/tutorial/first_output.txt
+++ b/docs/_static/tutorial/first_output.txt
@@ -1,17 +1,17 @@
-[ *** Cleanup *** ]
-[ -- Removing output for Test: first -- ]
+[SciATH][ *** Cleanup *** ]
+[SciATH] Removing output for Test: first
 
-[ *** Executing Tests *** ]
+[SciATH][ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[Executing first] from /Users/patrick/scratch/first_output/sandbox
+[SciATH][ Executing first ]from /Users/patrick/scratch/first_output/sandbox
 sh /Users/patrick/scratch/first_output/first.sh
 
-[ *** Summary *** ]
+[SciATH][ *** Summary *** ]
 [first]  pass
 [second]  deactivated
 [failing]  deactivated

--- a/docs/_static/tutorial/text_diff_fail_output.txt
+++ b/docs/_static/tutorial/text_diff_fail_output.txt
@@ -1,23 +1,23 @@
-[ *** Cleanup *** ]
-[ -- Removing output for Test: text_diff -- ]
+[SciATH][ *** Cleanup *** ]
+[SciATH] Removing output for Test: text_diff
 
-[ *** Executing Tests *** ]
+[SciATH][ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[Executing text_diff] from /Users/patrick/scratch/text_diff_output/sandbox
+[SciATH][ Executing text_diff ]from /Users/patrick/scratch/text_diff_output/sandbox
 sh /Users/patrick/scratch/text_diff_output/text_diff.sh
 
-[ *** Verification Reports *** ]
-[Report for text_diff]
+[SciATH][ *** Verification Reports *** ]
+[SciATH][ Report for text_diff ]
 [Comparison] Expected file missing: text_diff.expected
 check stdout file:
     less /Users/patrick/scratch/text_diff_output/text_diff.stdout
 
-[ *** Summary *** ]
+[SciATH][ *** Summary *** ]
 [first]  deactivated
 [second]  deactivated
 [failing]  deactivated

--- a/docs/_static/tutorial/tutorial1_output.txt
+++ b/docs/_static/tutorial/tutorial1_output.txt
@@ -1,17 +1,17 @@
-[ *** Cleanup *** ]
-[ -- Removing output for Test: first -- ]
+[SciATH][ *** Cleanup *** ]
+[SciATH] Removing output for Test: first
 
-[ *** Executing Tests *** ]
+[SciATH][ *** Executing Tests *** ]
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[Executing first] from /Users/patrick/scratch/first_output/sandbox
+[SciATH][ Executing first ]from /Users/patrick/scratch/first_output/sandbox
 sh /Users/patrick/scratch/first_output/first.sh
 
-[ *** Summary *** ]
+[SciATH][ *** Summary *** ]
 [first]  pass
 
 SUCCESS

--- a/sciath/__init__.py
+++ b/sciath/__init__.py
@@ -1,7 +1,12 @@
 """ SciATH: Scientific Application Test Harness """
-from sciath._sciath_io import NamedColors
+from sciath._sciath_colors import NamedColors
 
 __version__ = (0, 13, 0)
 
 # A default set of colors
 SCIATH_COLORS = NamedColors()
+
+
+def no_colors():
+    """ Deactivate text coloring """
+    SCIATH_COLORS.set_colors(use_bash=False)

--- a/sciath/_sciath_colors.py
+++ b/sciath/_sciath_colors.py
@@ -1,0 +1,18 @@
+""" SciATH colors for printing """
+
+
+class NamedColors:  #pylint: disable=too-few-public-methods
+    """ Color codes to use for SciATH output """
+
+    def __init__(self):
+        self.set_colors()
+
+    def set_colors(self, use_bash=True):
+        """ Set color codes, based on whether or not bash colors are used """
+        self.header = '\033[35m' if use_bash else ''
+        self.subheader = '\033[36m' if use_bash else ''
+        self.okay = '\033[32m' if use_bash else ''
+        self.warning = '\033[33m' if use_bash else ''
+        self.error = '\033[91m' if use_bash else ''
+        self.fail = '\033[91m' if use_bash else ''
+        self.endc = '\033[0m' if use_bash else ''

--- a/sciath/_sciath_io.py
+++ b/sciath/_sciath_io.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import os
 import sys
+from sciath import SCIATH_COLORS
 
 
 def py23input(prompt):
@@ -33,17 +34,89 @@ def command_join(command):
     return joined
 
 
-class NamedColors:  #pylint: disable=too-few-public-methods
-    """ Color codes to use for SciATH output """
+# Functions which color strings
+def color_error(string):
+    """ Colors a string as an error """
+    return "%s%s%s" % (SCIATH_COLORS.error, string, SCIATH_COLORS.endc)
 
-    def __init__(self):
-        self.set_colors()
 
-    def set_colors(self, use_bash=True):
-        """ Set color codes, based on whether or not bash colors are used """
-        self.header = '\033[35m' if use_bash else ''
-        self.subheader = '\033[36m' if use_bash else ''
-        self.okay = '\033[32m' if use_bash else ''
-        self.warning = '\033[33m' if use_bash else ''
-        self.fail = '\033[91m' if use_bash else ''
-        self.endc = '\033[0m' if use_bash else ''
+def color_fail(string):
+    """ Colors a string as a failure """
+    return "%s%s%s" % (SCIATH_COLORS.fail, string, SCIATH_COLORS.endc)
+
+
+def color_header(string):
+    """ Colors a string as a SciATH header """
+    return "%s%s%s" % (SCIATH_COLORS.header, string, SCIATH_COLORS.endc)
+
+
+def color_info(string):
+    """ Colors a string as SciATH info """
+    return string
+
+
+def color_okay(string):
+    """ Colors a string as okay """
+    return "%s%s%s" % (SCIATH_COLORS.okay, string, SCIATH_COLORS.endc)
+
+
+def color_subheader(string):
+    """ Colors a string as a SciATH subheader """
+    return "%s%s%s" % (SCIATH_COLORS.subheader, string, SCIATH_COLORS.endc)
+
+
+def color_warning(string):
+    """ Colors a string as a warning """
+    return "%s%s%s" % (SCIATH_COLORS.warning, string, SCIATH_COLORS.endc)
+
+
+# Functions which format strings
+def format_error(string):
+    """ Formats a string as a SciATH error """
+    return color_error("[SciATH] Error: %s" % string)
+
+
+def format_header(string):
+    """ Formats a string as a SciATH header """
+    return color_header("[SciATH][ *** %s *** ]" % string)
+
+
+def format_info(string):
+    """ Formats a string as SciATH info """
+    return color_info("[SciATH] %s" % string)
+
+
+def format_subheader(string):
+    """ Formats a string as a SciATH subheader """
+    return color_subheader("[SciATH][ %s ]" % string)
+
+
+def format_warning(string):
+    """ Formats a string as a SciATH warning """
+    return color_warning("[SciATH] Warning: %s" % string)
+
+
+# Functions which format and print strings
+def print_error(string, **kwargs):
+    """ Prints a string as a SciATH error """
+    print(format_error(string), **kwargs)
+
+
+def print_info(string, **kwargs):
+    """ Prints a string as SciATH information """
+    print(format_info(string), **kwargs)
+
+
+def print_header(string, **kwargs):
+    """ Prints a string as a SciATH header """
+    print(format_header(string), **kwargs)
+
+
+def print_subheader(string, **kwargs):
+    """ Prints a string as a SciATH subheader """
+    print(format_subheader(string), **kwargs)
+
+
+def print_warning(string, **kwargs):
+    """ Prints a string as a SciATH warning """
+    print(format_warning(string), **kwargs)

--- a/sciath/verifier.py
+++ b/sciath/verifier.py
@@ -8,6 +8,10 @@ import shutil
 import errno
 
 
+class SciATHVerifierMissingFileException(Exception):
+    """ Exception for a missing file required for a :class:`Verifier` operation """
+
+
 class Verifier(object):  # pylint: disable=bad-option-value,too-few-public-methods,useless-object-inheritance
     """Base class for verification of a Test"""
 
@@ -96,8 +100,8 @@ class ComparisonVerifier(Verifier):
         self.expected_file = expected_file
 
         if comparison_file and output_file:
-            raise Exception(
-                'Cannot specify an output_file with a comparison_file')
+            raise SciATHVerifierMissingFileException(
+                "Cannot specify an output_file with a comparison_file")
         self.comparison_file = comparison_file
 
         stdout_name = self.test.job.stdout_filename
@@ -136,15 +140,15 @@ class ComparisonVerifier(Verifier):
             """
         from_file = self._from_file(output_path, exec_path)
         if not os.path.isfile(from_file):
-            print('[SciATH] Cannot update: source file missing: %s' % from_file)
-        else:
-            try:
-                shutil.copy(from_file, self.expected_file)
-            except IOError as io_err:
-                if io_err.errno != errno.ENOENT:
-                    raise
-                os.makedirs(os.path.dirname(self.expected_file))
-                shutil.copyfile(from_file, self.expected_file)
+            raise SciATHVerifierMissingFileException(
+                "Cannot update: source file missing: %s" % from_file)
+        try:
+            shutil.copy(from_file, self.expected_file)
+        except IOError as io_err:
+            if io_err.errno != errno.ENOENT:
+                raise
+            os.makedirs(os.path.dirname(self.expected_file))
+            shutil.copyfile(from_file, self.expected_file)
 
     def _compare_files(self, from_file, to_file):  # pylint: disable=no-self-use
         passing = True

--- a/tests/test_data/capture_environment.expected
+++ b/tests/test_data/capture_environment.expected
@@ -1,17 +1,17 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: a_test -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: a_test
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing a_test][0m from <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/sandbox
+[36m[SciATH][ Executing a_test ][0mfrom <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/sandbox
 sh <<TEST DIR STRIPPED>>/capture_environment_sandbox/a_test_output/a_test.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[a_test]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/groups.expected
+++ b/tests/test_data/groups.expected
@@ -1,28 +1,28 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: testA -- ]
-[ -- Removing output for Test: testA_too -- ]
-[ -- Removing output for Test: testE -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: testA
+[SciATH] Removing output for Test: testA_too
+[SciATH] Removing output for Test: testE
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing testA][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/sandbox
+[36m[SciATH][ Executing testA ][0mfrom <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/sandbox
 sh <<TEST DIR STRIPPED>>/groups_sandbox/testA_output/testA.sh
-[36m[Executing testA_too][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testA_too_output/sandbox
+[36m[SciATH][ Executing testA_too ][0mfrom <<TEST DIR STRIPPED>>/groups_sandbox/testA_too_output/sandbox
 sh <<TEST DIR STRIPPED>>/groups_sandbox/testA_too_output/testA_too.sh
-[36m[Executing testE][0m from <<TEST DIR STRIPPED>>/groups_sandbox/testE_output/sandbox
+[36m[SciATH][ Executing testE ][0mfrom <<TEST DIR STRIPPED>>/groups_sandbox/testE_output/sandbox
 sh <<TEST DIR STRIPPED>>/groups_sandbox/testE_output/testE.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[testA]  pass[0m
 [32m[testA_too]  pass[0m
-[0m[testB]  deactivated[0m
-[0m[testC]  deactivated[0m
-[0m[testD]  deactivated[0m
+[testB]  deactivated
+[testC]  deactivated
+[testD]  deactivated
 [32m[testE]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/harness1.expected
+++ b/tests/test_data/harness1.expected
@@ -1,33 +1,33 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: test1 -- ]
-[ -- Removing output for Test: test2 -- ]
-[ -- Removing output for Test: test3 -- ]
-[ -- Removing output for Test: test4 -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: test1
+[SciATH] Removing output for Test: test2
+[SciATH] Removing output for Test: test3
+[SciATH] Removing output for Test: test4
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness1_sandbox/test1_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test2_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness1_sandbox/test2_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness1_sandbox/test2_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test3_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness1_sandbox/test3_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness1_sandbox/test3_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness1_sandbox/test4_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness1_sandbox/test4_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness1_sandbox/test4_output/job.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for test4][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for test4 ][0m
 [ExitCodeDiff] Expected exit code(s): [0]
 [ExitCodeDiff] Output exit code(s)  : [2]
 [33mcheck non-empty stderr file:[0m
     less <<TEST DIR STRIPPED>>/harness1_sandbox/test4_output/job.stderr
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[test1]  pass[0m
 [32m[test2]  pass[0m
 [32m[test3]  pass[0m

--- a/tests/test_data/harness2.expected
+++ b/tests/test_data/harness2.expected
@@ -1,33 +1,33 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: test1 -- ]
-[ -- Removing output for Test: test2 -- ]
-[ -- Removing output for Test: test3 -- ]
-[ -- Removing output for Test: test4 -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: test1
+[SciATH] Removing output for Test: test2
+[SciATH] Removing output for Test: test3
+[SciATH] Removing output for Test: test4
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness2_sandbox/test1_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test2_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness2_sandbox/test2_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness2_sandbox/test2_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test3_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness2_sandbox/test3_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness2_sandbox/test3_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness2_sandbox/test4_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness2_sandbox/test4_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness2_sandbox/test4_output/job.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for test4][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for test4 ][0m
 [ExitCodeDiff] Expected exit code(s): [0]
 [ExitCodeDiff] Output exit code(s)  : [2]
 [33mcheck non-empty stderr file:[0m
     less <<TEST DIR STRIPPED>>/harness2_sandbox/test4_output/job.stderr
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[test1]  pass[0m
 [32m[test2]  pass[0m
 [32m[test3]  pass[0m

--- a/tests/test_data/harness3.expected
+++ b/tests/test_data/harness3.expected
@@ -1,20 +1,20 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: test1 -- ]
-[ -- Removing output for Test: test2 -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: test1
+[SciATH] Removing output for Test: test2
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness3_sandbox/test1_output/job.sh
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness3_sandbox/test2_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness3_sandbox/test2_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness3_sandbox/test2_output/job.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[test1]  pass[0m
 [32m[test2]  pass[0m
 

--- a/tests/test_data/harness4.expected
+++ b/tests/test_data/harness4.expected
@@ -1,36 +1,36 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
-[ -- Removing output for Test: foo2 -- ]
-[ -- Removing output for Test: foo_fail -- ]
-[ -- Removing output for Test: missing -- ]
-[ -- Removing output for Test: many_words -- ]
-[ -- Removing output for Test: comp_file -- ]
-[ -- Removing output for Test: comp_file_fail -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
+[SciATH] Removing output for Test: foo2
+[SciATH] Removing output for Test: foo_fail
+[SciATH] Removing output for Test: missing
+[SciATH] Removing output for Test: many_words
+[SciATH] Removing output for Test: comp_file
+[SciATH] Removing output for Test: comp_file_fail
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo_output/foo.sh
-[36m[Executing foo2][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo2_output/sandbox
+[36m[SciATH][ Executing foo2 ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/foo2_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo2_output/foo2.sh
-[36m[Executing foo_fail][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/sandbox
+[36m[SciATH][ Executing foo_fail ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/foo_fail.sh
-[36m[Executing missing][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/sandbox
+[36m[SciATH][ Executing missing ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/missing.sh
-[36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/many_words_output/sandbox
+[36m[SciATH][ Executing many_words ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/many_words_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/many_words_output/many_words.sh
-[36m[Executing comp_file][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_output/sandbox
+[36m[SciATH][ Executing comp_file ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_output/comp_file.sh
-[36m[Executing comp_file_fail][0m from <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/sandbox
+[36m[SciATH][ Executing comp_file_fail ][0mfrom <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/comp_file_fail.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for foo_fail][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for foo_fail ][0m
 --- ../test_data/harness4/foo.expected
 +++ <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/foo_fail.stdout
 @@ -1 +1 @@
@@ -38,18 +38,18 @@ sh <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/comp_file_fail.s
 +foox
 check stdout file:
     less <<TEST DIR STRIPPED>>/harness4_sandbox/foo_fail_output/foo_fail.stdout
-[36m[Report for missing][0m
+[36m[SciATH][ Report for missing ][0m
 [Comparison] Expected file missing: ../test_data/harness4/missing.expected
 check stdout file:
     less <<TEST DIR STRIPPED>>/harness4_sandbox/missing_output/missing.stdout
-[36m[Report for comp_file_fail][0m
+[36m[SciATH][ Report for comp_file_fail ][0m
 --- ../test_data/harness4/comp_file_fail.expected
 +++ <<TEST DIR STRIPPED>>/harness4_sandbox/comp_file_fail_output/sandbox/compare_me.txt
 @@ -1 +1 @@
 -foo
 +qux
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[foo]  pass[0m
 [32m[foo2]  pass[0m
 [91m[foo_fail]  fail[0m

--- a/tests/test_data/harness5.expected
+++ b/tests/test_data/harness5.expected
@@ -1,18 +1,18 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: test -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: test
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing job][0m from <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/sandbox
+[36m[SciATH][ Executing job ][0mfrom <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/sandbox
 sh <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/job.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for test][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for test ][0m
 --- <<TEST DIR STRIPPED>>/test_data/harness5/test.expected
 +++ <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/job.stdout
 Report for 1 expected line(s) matching: '^\s*The\ first\ number\ is'
@@ -21,7 +21,7 @@ Output line 1 did not match line 1 in expected output:
 check stdout file:
     less <<TEST DIR STRIPPED>>/harness5_sandbox/test_output/job.stdout
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [91m[test]  fail[0m
 
 [91mFAILURE[0m

--- a/tests/test_data/module_input.expected
+++ b/tests/test_data/module_input.expected
@@ -1,36 +1,36 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
-[ -- Removing output for Test: foo2 -- ]
-[ -- Removing output for Test: foo_fail -- ]
-[ -- Removing output for Test: missing -- ]
-[ -- Removing output for Test: many_words -- ]
-[ -- Removing output for Test: comp_file -- ]
-[ -- Removing output for Test: comp_file_fail -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
+[SciATH] Removing output for Test: foo2
+[SciATH] Removing output for Test: foo_fail
+[SciATH] Removing output for Test: missing
+[SciATH] Removing output for Test: many_words
+[SciATH] Removing output for Test: comp_file
+[SciATH] Removing output for Test: comp_file_fail
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/foo.sh
-[36m[Executing foo2][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo2_output/sandbox
+[36m[SciATH][ Executing foo2 ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/foo2_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo2_output/foo2.sh
-[36m[Executing foo_fail][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/sandbox
+[36m[SciATH][ Executing foo_fail ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/foo_fail.sh
-[36m[Executing missing][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/sandbox
+[36m[SciATH][ Executing missing ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/missing.sh
-[36m[Executing many_words][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/many_words_output/sandbox
+[36m[SciATH][ Executing many_words ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/many_words_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/many_words_output/many_words.sh
-[36m[Executing comp_file][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_output/sandbox
+[36m[SciATH][ Executing comp_file ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_output/comp_file.sh
-[36m[Executing comp_file_fail][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/sandbox
+[36m[SciATH][ Executing comp_file_fail ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/comp_file_fail.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for foo_fail][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for foo_fail ][0m
 --- ../test_data/module_input/foo.expected
 +++ <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/foo_fail.stdout
 @@ -1 +1 @@
@@ -38,18 +38,18 @@ sh <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/comp_file_fa
 +foox
 check stdout file:
     less <<TEST DIR STRIPPED>>/module_input_sandbox/foo_fail_output/foo_fail.stdout
-[36m[Report for missing][0m
+[36m[SciATH][ Report for missing ][0m
 [Comparison] Expected file missing: ../test_data/module_input/missing.expected
 check stdout file:
     less <<TEST DIR STRIPPED>>/module_input_sandbox/missing_output/missing.stdout
-[36m[Report for comp_file_fail][0m
+[36m[SciATH][ Report for comp_file_fail ][0m
 --- ../test_data/module_input/comp_file_fail.expected
 +++ <<TEST DIR STRIPPED>>/module_input_sandbox/comp_file_fail_output/sandbox/compare_me.txt
 @@ -1 +1 @@
 -foo
 +qux
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[foo]  pass[0m
 [32m[foo2]  pass[0m
 [91m[foo_fail]  fail[0m

--- a/tests/test_data/module_line_verifier.expected
+++ b/tests/test_data/module_line_verifier.expected
@@ -1,24 +1,24 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
-[ -- Removing output for Test: foo_again -- ]
-[ -- Removing output for Test: bar -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
+[SciATH] Removing output for Test: foo_again
+[SciATH] Removing output for Test: bar
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_output/foo.sh
-[36m[Executing foo_again][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/foo_again_output/sandbox
+[36m[SciATH][ Executing foo_again ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/foo_again_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/foo_again_output/foo_again.sh
-[36m[Executing bar][0m from <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/sandbox
+[36m[SciATH][ Executing bar ][0mfrom <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/bar.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for bar][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for bar ][0m
 --- <<TEST DIR STRIPPED>>/test_data/module_line_verifier/bar.expected
 +++ <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/bar.stdout
 Report for 3 expected line(s) matching: '^'
@@ -28,7 +28,7 @@ Wrong number of matched lines: 4 instead of 3
 check stdout file:
     less <<TEST DIR STRIPPED>>/module_input_sandbox/bar_output/bar.stdout
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[foo]  pass[0m
 [32m[foo_again]  pass[0m
 [91m[bar]  fail[0m

--- a/tests/test_data/module_multi.expected
+++ b/tests/test_data/module_multi.expected
@@ -1,23 +1,23 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: testA -- ]
-[ -- Removing output for Test: testA_too -- ]
-[ -- Removing output for Test: testB -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: testA
+[SciATH] Removing output for Test: testA_too
+[SciATH] Removing output for Test: testB
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing testA][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/sandbox
+[36m[SciATH][ Executing testA ][0mfrom <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_output/testA.sh
-[36m[Executing testA_too][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_too_output/sandbox
+[36m[SciATH][ Executing testA_too ][0mfrom <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_too_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testA_too_output/testA_too.sh
-[36m[Executing testB][0m from <<TEST DIR STRIPPED>>/module_multi_sandbox/testB_output/sandbox
+[36m[SciATH][ Executing testB ][0mfrom <<TEST DIR STRIPPED>>/module_multi_sandbox/testB_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_multi_sandbox/testB_output/testB.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[testA]  pass[0m
 [32m[testA_too]  pass[0m
 [32m[testB]  pass[0m

--- a/tests/test_data/module_relpath.expected
+++ b/tests/test_data/module_relpath.expected
@@ -1,17 +1,17 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: relpath_test -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: relpath_test
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing relpath_test][0m from <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/sandbox
+[36m[SciATH][ Executing relpath_test ][0mfrom <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/sandbox
 sh <<TEST DIR STRIPPED>>/module_relpath_sandbox/relpath_test_output/relpath_test.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[relpath_test]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/mpi_different_ranks_execute.expected
+++ b/tests/test_data/mpi_different_ranks_execute.expected
@@ -1,13 +1,13 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: varying_ranks -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: varying_ranks
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing varying_ranks][0m from <<TEST DIR STRIPPED>>/mpi_different_ranks_execute_sandbox/varying_ranks_output/sandbox
+[36m[SciATH][ Executing varying_ranks ][0mfrom <<TEST DIR STRIPPED>>/mpi_different_ranks_execute_sandbox/varying_ranks_output/sandbox
 sh <<TEST DIR STRIPPED>>/mpi_different_ranks_execute_sandbox/varying_ranks_output/varying_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/mpi_different_ranks_verify.expected
+++ b/tests/test_data/mpi_different_ranks_verify.expected
@@ -1,5 +1,5 @@
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[varying_ranks]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/mpi_smoke_execute.expected
+++ b/tests/test_data/mpi_smoke_execute.expected
@@ -1,13 +1,13 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: two_ranks -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: two_ranks
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/sandbox
+[36m[SciATH][ Executing two_ranks ][0mfrom <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/sandbox
 sh <<TEST DIR STRIPPED>>/mpi_smoke_execute_sandbox/two_ranks_output/two_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/mpi_smoke_two_ranks_execute.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_execute.expected
@@ -1,13 +1,13 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: two_ranks -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: two_ranks
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      /Users/patrick/code/petsc/arch-mpich-only/bin/mpiexec -n <ranks>
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/sandbox
+[36m[SciATH][ Executing two_ranks ][0mfrom <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/sandbox
 sh <<TEST DIR STRIPPED>>/mpi_smoke_two_ranks_execute_sandbox/two_ranks_output/two_ranks.sh
 [SciATH] Not verifying or reporting

--- a/tests/test_data/mpi_smoke_two_ranks_verify.expected
+++ b/tests/test_data/mpi_smoke_two_ranks_verify.expected
@@ -1,5 +1,5 @@
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[two_ranks]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/mpi_smoke_verify.expected
+++ b/tests/test_data/mpi_smoke_verify.expected
@@ -1,5 +1,5 @@
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[two_ranks]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/multiple_input_files.expected
+++ b/tests/test_data/multiple_input_files.expected
@@ -1,23 +1,23 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
-[ -- Removing output for Test: bar -- ]
-[ -- Removing output for Test: baz -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
+[SciATH] Removing output for Test: bar
+[SciATH] Removing output for Test: baz
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/foo_output/foo.sh
-[36m[Executing bar][0m from <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/bar_output/sandbox
+[36m[SciATH][ Executing bar ][0mfrom <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/bar_output/sandbox
 sh <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/bar_output/bar.sh
-[36m[Executing baz][0m from <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/baz_output/sandbox
+[36m[SciATH][ Executing baz ][0mfrom <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/baz_output/sandbox
 sh <<TEST DIR STRIPPED>>/multiple_input_files_sandbox/baz_output/baz.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[foo]  pass[0m
 [32m[bar]  pass[0m
 [32m[baz]  pass[0m

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -1,21 +1,21 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: two_ranks -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: two_ranks
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing two_ranks][0m from <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/sandbox
+[36m[SciATH][ Executing two_ranks ][0mfrom <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/sandbox
 sh <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/two_ranks.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for two_ranks][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for two_ranks ][0m
 Not launched: requires MPI
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [33m[two_ranks]  skipped[0m (MPI required)
 
 [91mFAILURE[0m

--- a/tests/test_data/verifier_line_atol.expected
+++ b/tests/test_data/verifier_line_atol.expected
@@ -1,39 +1,39 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: rtol_only_default_fail -- ]
-[ -- Removing output for Test: rtol_only_fail -- ]
-[ -- Removing output for Test: atol_only_fail -- ]
-[ -- Removing output for Test: both_tols_fail -- ]
-[ -- Removing output for Test: atol_zero_fail -- ]
-[ -- Removing output for Test: rtol_zero_fail -- ]
-[ -- Removing output for Test: both_tols_zero_fail -- ]
-[ -- Removing output for Test: both_tols_pass -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: rtol_only_default_fail
+[SciATH] Removing output for Test: rtol_only_fail
+[SciATH] Removing output for Test: atol_only_fail
+[SciATH] Removing output for Test: both_tols_fail
+[SciATH] Removing output for Test: atol_zero_fail
+[SciATH] Removing output for Test: rtol_zero_fail
+[SciATH] Removing output for Test: both_tols_zero_fail
+[SciATH] Removing output for Test: both_tols_pass
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing rtol_only_default_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/sandbox
+[36m[SciATH][ Executing rtol_only_default_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/rtol_only_default_fail.sh
-[36m[Executing rtol_only_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/sandbox
+[36m[SciATH][ Executing rtol_only_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/rtol_only_fail.sh
-[36m[Executing atol_only_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/sandbox
+[36m[SciATH][ Executing atol_only_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/atol_only_fail.sh
-[36m[Executing both_tols_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/sandbox
+[36m[SciATH][ Executing both_tols_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/both_tols_fail.sh
-[36m[Executing atol_zero_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/sandbox
+[36m[SciATH][ Executing atol_zero_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/atol_zero_fail.sh
-[36m[Executing rtol_zero_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/sandbox
+[36m[SciATH][ Executing rtol_zero_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/rtol_zero_fail.sh
-[36m[Executing both_tols_zero_fail][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/sandbox
+[36m[SciATH][ Executing both_tols_zero_fail ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/both_tols_zero_fail.sh
-[36m[Executing both_tols_pass][0m from <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_pass_output/sandbox
+[36m[SciATH][ Executing both_tols_pass ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_pass_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_pass_output/both_tols_pass.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for rtol_only_default_fail][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for rtol_only_default_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/rtol_only_default_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -48,7 +48,7 @@ Output line 11 did not match line 11 in expected output:
 1.00001 != 1 to rel. tol. 1e-06 (rel. err. 1e-05)
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_default_fail_output/rtol_only_default_fail.stdout
-[36m[Report for rtol_only_fail][0m
+[36m[SciATH][ Report for rtol_only_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/rtol_only_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -60,7 +60,7 @@ Output line 11 did not match line 11 in expected output:
 1e-14 != 1e-16 to rel. tol. 0.001 (rel. err. 99)
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_only_fail_output/rtol_only_fail.stdout
-[36m[Report for atol_only_fail][0m
+[36m[SciATH][ Report for atol_only_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/atol_only_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -74,7 +74,7 @@ Output line 11 did not match line 11 in expected output:
 1.00001 != 1 to abs. tol. 1e-12 (abs. err 1e-05)
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_only_fail_output/atol_only_fail.stdout
-[36m[Report for both_tols_fail][0m
+[36m[SciATH][ Report for both_tols_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/both_tols_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -89,7 +89,7 @@ Output line 11 did not match line 11 in expected output:
 1.00001 != 1 to abs. tol. 1e-99 (abs. err 1e-05) or rel. tol 1e-10 (rel. err 1e-05)
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_fail_output/both_tols_fail.stdout
-[36m[Report for atol_zero_fail][0m
+[36m[SciATH][ Report for atol_zero_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/atol_zero_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -108,7 +108,7 @@ Output line 11 did not match line 11 in expected output:
 1.00001 != 1 to abs. tol. 0 (abs. err 1e-05)
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/atol_zero_fail_output/atol_zero_fail.stdout
-[36m[Report for rtol_zero_fail][0m
+[36m[SciATH][ Report for rtol_zero_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/rtol_zero_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -127,7 +127,7 @@ Output line 11 did not match line 11 in expected output:
 1.00001 != 1 to rel. tol. 0 (rel. err. 1e-05)
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/rtol_zero_fail_output/rtol_zero_fail.stdout
-[36m[Report for both_tols_zero_fail][0m
+[36m[SciATH][ Report for both_tols_zero_fail ][0m
 --- <<TEST DIR STRIPPED>>/test_data/verifier_line_atol/expected
 +++ <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/both_tols_zero_fail.stdout
 Report for 11 expected line(s) matching: '^\s*key'
@@ -147,7 +147,7 @@ Output line 11 did not match line 11 in expected output:
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_line_atol_sandbox/both_tols_zero_fail_output/both_tols_zero_fail.stdout
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [91m[rtol_only_default_fail]  fail[0m
 [91m[rtol_only_fail]  fail[0m
 [91m[atol_only_fail]  fail[0m

--- a/tests/test_data/verifier_line_order.expected
+++ b/tests/test_data/verifier_line_order.expected
@@ -1,17 +1,17 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: run -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: run
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing run][0m from <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/sandbox
+[36m[SciATH][ Executing run ][0mfrom <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_line_order_sandbox/run_output/run.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[run]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/verifier_update.expected
+++ b/tests/test_data/verifier_update.expected
@@ -1,18 +1,18 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for foo][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for foo ][0m
 --- expected
 +++ <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.stdout
 @@ -1 +1 @@
@@ -21,7 +21,7 @@ sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 check stdout file:
     less <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.stdout
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [91m[foo]  fail[0m
 
 [91mFAILURE[0m
@@ -32,42 +32,42 @@ Report written to file:
   <<TEST DIR STRIPPED>>/verifier_update_sandbox/sciath_test_report.txt
 [SciATH] You have provided an argument to updated expected files.
 [SciATH] This will attempt to OVERWRITE your expected files!
-[SciATH] Are you sure? Type 'y' to continue: [35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
+[SciATH] Are you sure? Type 'y' to continue: [35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
-[35m[ *** Updating Expected Output *** ][0m
-[ -- Updating output for Test: foo -- ]
+[35m[SciATH][ *** Updating Expected Output *** ][0m
+[SciATH] Updating output for Test: foo
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[foo]  pass[0m
 
 [32mSUCCESS[0m
 
 Report written to file:
   <<TEST DIR STRIPPED>>/verifier_update_sandbox/sciath_test_report.txt
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: foo -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: foo
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing foo][0m from <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
+[36m[SciATH][ Executing foo ][0mfrom <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/sandbox
 sh <<TEST DIR STRIPPED>>/verifier_update_sandbox/foo_output/foo.sh
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[foo]  pass[0m
 
 [32mSUCCESS[0m

--- a/tests/test_data/verify_exitcode.expected
+++ b/tests/test_data/verify_exitcode.expected
@@ -1,46 +1,46 @@
-[35m[ *** Cleanup *** ][0m
-[ -- Removing output for Test: should_pass -- ]
-[ -- Removing output for Test: should_fail -- ]
-[ -- Removing output for Test: should_pass_multi -- ]
-[ -- Removing output for Test: should_fail_multi -- ]
-[ -- Removing output for Test: should_fail_multi2 -- ]
-[ -- Removing output for Test: should_fail_multi3 -- ]
+[35m[SciATH][ *** Cleanup *** ][0m
+[SciATH] Removing output for Test: should_pass
+[SciATH] Removing output for Test: should_fail
+[SciATH] Removing output for Test: should_pass_multi
+[SciATH] Removing output for Test: should_fail_multi
+[SciATH] Removing output for Test: should_fail_multi2
+[SciATH] Removing output for Test: should_fail_multi3
 
-[35m[ *** Executing Tests *** ][0m
+[35m[SciATH][ *** Executing Tests *** ][0m
 [SciATH] Batch queueing system configuration [SciATH_launcher.conf]
   Version:           0.13.0
   MPI launcher:      none
   Submit command:    sh
   Blocking:          True
   Job-level ranks:   False
-[36m[Executing should_pass][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/sandbox
+[36m[SciATH][ Executing should_pass ][0mfrom <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_output/should_pass.sh
-[36m[Executing should_fail][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_output/sandbox
+[36m[SciATH][ Executing should_fail ][0mfrom <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_output/should_fail.sh
-[36m[Executing should_pass_multi][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_multi_output/sandbox
+[36m[SciATH][ Executing should_pass_multi ][0mfrom <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_multi_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_pass_multi_output/should_pass_multi.sh
-[36m[Executing should_fail_multi][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi_output/sandbox
+[36m[SciATH][ Executing should_fail_multi ][0mfrom <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi_output/should_fail_multi.sh
-[36m[Executing should_fail_multi2][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi2_output/sandbox
+[36m[SciATH][ Executing should_fail_multi2 ][0mfrom <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi2_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi2_output/should_fail_multi2.sh
-[36m[Executing should_fail_multi3][0m from <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi3_output/sandbox
+[36m[SciATH][ Executing should_fail_multi3 ][0mfrom <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi3_output/sandbox
 sh <<TEST DIR STRIPPED>>/verify_exitcode_sandbox/should_fail_multi3_output/should_fail_multi3.sh
 
-[35m[ *** Verification Reports *** ][0m
-[36m[Report for should_fail][0m
+[35m[SciATH][ *** Verification Reports *** ][0m
+[36m[SciATH][ Report for should_fail ][0m
 [ExitCodeDiff] Expected exit code(s): [0]
 [ExitCodeDiff] Output exit code(s)  : [1]
-[36m[Report for should_fail_multi][0m
+[36m[SciATH][ Report for should_fail_multi ][0m
 [ExitCodeDiff] Expected exit code(s): [0, 0]
 [ExitCodeDiff] Output exit code(s)  : [0, 1]
-[36m[Report for should_fail_multi2][0m
+[36m[SciATH][ Report for should_fail_multi2 ][0m
 [ExitCodeDiff] Expected exit code(s): [0, 0]
 [ExitCodeDiff] Output exit code(s)  : [1, 1]
-[36m[Report for should_fail_multi3][0m
+[36m[SciATH][ Report for should_fail_multi3 ][0m
 [ExitCodeDiff] Expected exit code(s): [0, 0]
 [ExitCodeDiff] Output exit code(s)  : [1, 0]
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [32m[should_pass]  pass[0m
 [91m[should_fail]  fail[0m
 [32m[should_pass_multi]  pass[0m

--- a/tests/test_data/verify_unlaunched.expected
+++ b/tests/test_data/verify_unlaunched.expected
@@ -1,5 +1,5 @@
 
-[35m[ *** Summary *** ][0m
+[35m[SciATH][ *** Summary *** ][0m
 [33m[foo]  not launched[0m
 
 [91mFAILURE[0m


### PR DESCRIPTION
* Re-add a dedicated file for NamedColors
* Add helper functions for
  - coloring strings
  - formatting strings
  - printing formatted strings
* Use these helper functions within Harness to avoid direct use of colors and formatting conventions
* Restrict use of SCIATH_COLORS to __init__.py and _sciath_io.py
* Update some output formatting with the new helpers
* Change a printed error in verifier.py to a custom exception and handle
  at the Harness level

Partially addresses #27 