### PR TITLE
Launcher, Harness: split job submission

### DIFF
--- a/sciath/harness.py
+++ b/sciath/harness.py
@@ -106,7 +106,7 @@ class Harness:
                         testrun.exec_path, self._sandbox_sentinel_filename)
                     if not os.path.exists(sentinel_file):
                         raise SciATHHarnessInconsistentStateException(
-                            '[SciATH] did not find expected sentinel file ' +
+                            'Did not find expected sentinel file ' +
                             sentinel_file)
                     shutil.rmtree(testrun.exec_path)
 
@@ -119,7 +119,7 @@ class Harness:
                 return False
         return True
 
-    def execute(self):
+    def execute(self):  #pylint: disable=too-many-branches
         """ Execute all tests """
         self.clean()
 
@@ -142,22 +142,24 @@ class Harness:
                         testrun.exec_path, self._sandbox_sentinel_filename)
                     if os.path.exists(sentinel_file):
                         raise SciATHHarnessInconsistentStateException(
-                            "[SciATH] Unexpected sentinel file %s" %
-                            sentinel_file)
+                            "Unexpected sentinel file %s" % sentinel_file)
                     with open(sentinel_file, 'w'):
                         pass
                 if not self.quiet:
                     print_subheader("Executing %s" % testrun.test.job.name,
                                     end="")
                     print("from %s" % testrun.exec_path)
-                    print(
-                        command_join(
-                            self.launcher.launch_command(
-                                testrun.test.job, testrun.output_path)))
-                success, info, report = self.launcher.submit_job(
+                success, info, report, submit_data = self.launcher.prepare_job(
                     testrun.test.job,
                     output_path=testrun.output_path,
                     exec_path=testrun.exec_path)
+                if success:
+                    if not self.quiet:
+                        print(command_join(submit_data.launch_command))
+                    success, info, report = self.launcher.submit_job(
+                        submit_data)
+                else:
+                    print("# skipped (%s)" % info)
                 if not success:
                     testrun.status = _TestRunStatus.SKIPPED
                     testrun.status_info = info

--- a/tests/test_data/multiple_ranks_no_mpi.expected
+++ b/tests/test_data/multiple_ranks_no_mpi.expected
@@ -9,7 +9,7 @@
   Blocking:          True
   Job-level ranks:   False
 [36m[Executing two_ranks][0mfrom <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/sandbox
-sh <<TEST DIR STRIPPED>>/multiple_ranks_no_mpi_sandbox/two_ranks_output/two_ranks.sh
+# skipped (MPI required)
 
 [35m[*** Verification Reports ***][0m
 [36m[Report for two_ranks][0m

--- a/tests/test_data/test1/test_ex1.py
+++ b/tests/test_data/test1/test_ex1.py
@@ -13,9 +13,9 @@ EXEC_PATH = os.getcwd()
 job_launcher = Launcher()
 
 
-def test_print_pre(test, output_path, exec_path):
+def test_print_pre(test, exec_path, launch_command):
     print("[%s] Executing from %s" % (test.job.name, exec_path))
-    print(command_join(job_launcher.launch_command(test.job, output_path)))
+    print(command_join(launch_command))
 
 
 def test_print_post(test, output_path):
@@ -30,8 +30,10 @@ def test1():  # result: pass
     cmd = ['printf', '"aBc\nkspits=30\n"']
 
     t = Test(Job(Task(cmd), 'Test_1'))
-    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    success, info, report, data = job_launcher.prepare_job(
+        t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    test_print_pre(t, exec_path=EXEC_PATH, launch_command=data.launch_command)
+    job_launcher.submit_job(data)
     t.verify(output_path=OUTPUT_PATH)
     test_print_post(t, output_path=OUTPUT_PATH)
     return t
@@ -41,8 +43,10 @@ def test2():  # result: pass
     cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_2'))
-    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    success, info, report, data = job_launcher.prepare_job(
+        t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    test_print_pre(t, exec_path=EXEC_PATH, launch_command=data.launch_command)
+    job_launcher.submit_job(data)
     t.verify(output_path=OUTPUT_PATH)
     test_print_post(t, output_path=OUTPUT_PATH)
     return t
@@ -53,8 +57,10 @@ def test3():  # result: fail
 
     t = Test(Job(Task(cmd), 'Test_3'))
     t.verifier.set_exit_codes_success([1])
-    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    success, info, report, data = job_launcher.prepare_job(
+        t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    test_print_pre(t, exec_path=EXEC_PATH, launch_command=data.launch_command)
+    job_launcher.submit_job(data)
     t.verify(output_path=OUTPUT_PATH)
     test_print_post(t, output_path=OUTPUT_PATH)
     return t
@@ -64,8 +70,10 @@ def test4():  # result: pass
     cmd = ['printf', 'aBc\nkspits=30\n']
 
     t = Test(Job(Task(cmd), 'Test_4'))
-    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
-    job_launcher.submit_job(t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    success, info, report, data = job_launcher.prepare_job(
+        t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    test_print_pre(t, exec_path=EXEC_PATH, launch_command=data.launch_command)
+    job_launcher.submit_job(data)
     return t
 
 

--- a/tests/test_data/test2/test_ex2.py
+++ b/tests/test_data/test2/test_ex2.py
@@ -16,9 +16,9 @@ EXEC_PATH = os.getcwd()
 job_launcher = Launcher()
 
 
-def test_print_pre(test, output_path, exec_path):
+def test_print_pre(test, exec_path, launch_command):
     print("[%s] Executing from %s" % (test.job.name, exec_path))
-    print(command_join(job_launcher.launch_command(test.job, output_path)))
+    print(command_join(launch_command))
 
 
 def test_print_post(test, output_path):
@@ -34,10 +34,10 @@ def test1_ud():  # result: pass
     t = Test(Job(Task(cmd), 'Test_1_ud'))
     t.verifier = ComparisonVerifier(t, os.path.join(this_dir, "t1.expected"))
 
-    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
-    job_launcher.submit_job(t.job,
-                            output_path=OUTPUT_PATH,
-                            exec_path=OUTPUT_PATH)
+    success, info, report, data = job_launcher.prepare_job(
+        t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    test_print_pre(t, exec_path=EXEC_PATH, launch_command=data.launch_command)
+    job_launcher.submit_job(data)
     t.verify(output_path=OUTPUT_PATH)
     test_print_post(t, output_path=OUTPUT_PATH)
     return t
@@ -49,10 +49,10 @@ def test2_ud():  # result: fail
     t = Test(Job(Task(cmd), 'Test_2_ud'))
     t.verifier = ComparisonVerifier(t, os.path.join(this_dir, "t1.expected"))
 
-    test_print_pre(t, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
-    job_launcher.submit_job(t.job,
-                            output_path=OUTPUT_PATH,
-                            exec_path=OUTPUT_PATH)
+    success, info, report, data = job_launcher.prepare_job(
+        t.job, output_path=OUTPUT_PATH, exec_path=EXEC_PATH)
+    test_print_pre(t, exec_path=EXEC_PATH, launch_command=data.launch_command)
+    job_launcher.submit_job(data)
     t.verify(output_path=OUTPUT_PATH)
     test_print_post(t, output_path=OUTPUT_PATH)
     return t

--- a/tests/test_data/verifier_line/test_line_verifier.py
+++ b/tests/test_data/verifier_line/test_line_verifier.py
@@ -114,7 +114,9 @@ def main():
             test4(output_path),
             test5(output_path)
     ]:
-        launcher.submit_job(t.job, output_path=output_path)
+        success, info, report, data = launcher.prepare_job(
+            t.job, output_path=output_path)
+        launcher.submit_job(data)
         passing, info, report = t.verify(
             output_path=output_path)  # only makes sense if submit_job blocks
         print(passing)


### PR DESCRIPTION
Split job submission into two stages, to allow for diagnostics
after the Launcher has a chance to analyze a Job to see if it is
launchable, but before it actually runs it (which may block).

Closes #201 